### PR TITLE
Refactor compare function and add tests

### DIFF
--- a/policy/compare.go
+++ b/policy/compare.go
@@ -1,17 +1,15 @@
 package policy
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor"
 
-	"github.com/google/uuid"
 	"github.com/jonhadfield/findexec"
 	"github.com/sirupsen/logrus"
 )
@@ -21,105 +19,91 @@ func compare(original interface{}, updated []byte) (differencesFound bool, err e
 
 	logrus.Debugf("%s | finding differences between the current policy version and the proposed", funcName)
 
-	var originalBytes []byte
-
-	switch v := original.(type) {
-	case *armfrontdoor.WebApplicationFirewallPolicy:
-		originalBytes, err = json.MarshalIndent(v, "", "  ")
-		if err != nil {
-			return
-		}
-	case []byte:
-		break
-	default:
-		return false, errors.New("unexpected type")
-	}
-
 	diffBinary := findexec.Find("diff", "")
 	if diffBinary == "" {
-		err = errors.New("failed to find compare binary")
-
-		return
+		return false, errors.New("failed to find compare binary")
 	}
 
-	// getTagsWithNotes tempdir
-	tempDir := os.TempDir()
-	if !strings.HasSuffix(tempDir, string(os.PathSeparator)) {
-		tempDir += string(os.PathSeparator)
-	}
-
-	originalJSONB, err := json.MarshalIndent(original, "", "  ")
+	origJSON, err := marshalJSON(original)
 	if err != nil {
-		return
+		return false, err
 	}
 
-	newJSONB, err := json.MarshalIndent(updated, "", "  ")
+	newJSON, err := marshalJSON(updated)
 	if err != nil {
-		return
+		return false, err
 	}
 
-	originalJSON := string(originalJSONB)
-	newJSON := string(newJSONB)
-
-	if originalJSON == newJSON {
+	if bytes.Equal(origJSON, newJSON) {
 		return false, nil
 	}
 
 	differencesFound = true
 
-	// write local and remote content to temporary files
-	var f1, f2 *os.File
-
-	uid := uuid.New().String()
-	f1path := filepath.Join(tempDir, fmt.Sprintf("waf-afd-policy-%s-f1", uid))
-	f1path = filepath.Clean(f1path)
-
-	f2path := filepath.Join(tempDir, fmt.Sprintf("waf-afd-policy-%s-f2", uid))
-	f2path = filepath.Clean(f2path)
-
-	// #nosec
-	f1, err = os.Create(f1path)
+	f1, err := writeTempFile(origJSON)
 	if err != nil {
-		return
+		return false, err
 	}
-	// #nosec
-	f2, err = os.Create(f2path)
+	defer os.Remove(f1)
+
+	f2, err := writeTempFile(newJSON)
 	if err != nil {
-		return
+		return false, err
 	}
+	defer os.Remove(f2)
 
-	if _, err = f1.Write(originalBytes); err != nil {
-		return
-	}
-
-	if _, err = f2.WriteString(newJSON); err != nil {
-		return
-	}
-
-	// #nosec
-	cmd := exec.Command(diffBinary, "-u", f1path, f2path)
-
-	_, oErr := cmd.CombinedOutput()
-
-	if err = os.Remove(f1path); err != nil {
-		return
-	}
-
-	if err = os.Remove(f2path); err != nil {
-		return
-	}
-
-	var exitCode int
-
-	if oErr != nil {
-		if exitError, ok := oErr.(*exec.ExitError); ok {
-			exitCode = exitError.ExitCode()
-		}
+	exitCode, err := runDiff(diffBinary, f1, f2)
+	if err != nil {
+		return false, err
 	}
 
 	if exitCode == 2 {
-		panic(fmt.Sprintf("failed to compare: '%s' with '%s'", f1path, f2path))
+		return false, fmt.Errorf("failed to compare: '%s' with '%s'", f1, f2)
 	}
 
-	return differencesFound, err
+	return differencesFound, nil
+}
+
+func marshalJSON(v interface{}) ([]byte, error) {
+	switch val := v.(type) {
+	case []byte:
+		var out interface{}
+		if err := json.Unmarshal(val, &out); err != nil {
+			return nil, err
+		}
+		return json.MarshalIndent(out, "", "  ")
+	case *armfrontdoor.WebApplicationFirewallPolicy:
+		return json.MarshalIndent(val, "", "  ")
+	default:
+		return nil, errors.New("unexpected type")
+	}
+}
+
+func writeTempFile(data []byte) (string, error) {
+	f, err := os.CreateTemp("", "waf-afd-policy-")
+	if err != nil {
+		return "", err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+func runDiff(binary, f1, f2 string) (int, error) {
+	// #nosec
+	cmd := exec.Command(binary, "-u", f1, f2)
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			return exitError.ExitCode(), nil
+		}
+		return 0, err
+	}
+	return 0, nil
 }

--- a/policy/compare_test.go
+++ b/policy/compare_test.go
@@ -1,0 +1,26 @@
+package policy
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCompareIdentical(t *testing.T) {
+	orig := []byte(`{"a":1}`)
+	diff, err := compare(orig, orig)
+	require.NoError(t, err)
+	require.False(t, diff)
+}
+
+func TestCompareDifferent(t *testing.T) {
+	orig := []byte(`{"a":1}`)
+	updated := []byte(`{"a":2}`)
+	diff, err := compare(orig, updated)
+	require.NoError(t, err)
+	require.True(t, diff)
+}
+
+func TestCompareInvalidType(t *testing.T) {
+	_, err := compare(42, []byte(`{}`))
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- simplify the `compare` function by splitting helpers
- add unit tests for `compare`

## Testing
- `go test ./...` *(fails: Forbidden downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_6840626a857c8320a2f3edf39e269e96