### PR TITLE
Simplify directory creation and fix tests

### DIFF
--- a/policy/backup_test.go
+++ b/policy/backup_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestGeneratePolicyToRestoreBackupOnly(t *testing.T) {
-	policyTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-two.json")
+	policyTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
 	require.NoError(t, err)
 
-	policyTwoStatic, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-two.json")
+	policyTwoStatic, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
 	require.NoError(t, err)
 
 	// test that if only backup provided, that backup is returned
@@ -21,12 +21,12 @@ func TestGeneratePolicyToRestoreBackupOnly(t *testing.T) {
 }
 
 func TestGeneratePolicyToRestoreBackupWithoutOptions(t *testing.T) {
-	policyOne, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-one.json")
+	policyOne, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-one.json")
 	require.NoError(t, err)
-	policyTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-two.json")
+	policyTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
 	require.NoError(t, err)
 
-	policyTwoStatic, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-two.json")
+	policyTwoStatic, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
 	require.NoError(t, err)
 
 	// test that providing two Policies without options returns Original with backup rules replacing Original's
@@ -36,14 +36,14 @@ func TestGeneratePolicyToRestoreBackupWithoutOptions(t *testing.T) {
 }
 
 func TestGeneratePolicyToRestoreBackupCustomOnly(t *testing.T) {
-	policyOne, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-one.json")
+	policyOne, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-one.json")
 	require.NoError(t, err)
-	policyTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-two.json")
+	policyTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
 	require.NoError(t, err)
 
-	policyOneStatic, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-one.json")
+	policyOneStatic, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-one.json")
 	require.NoError(t, err)
-	policyTwoStatic, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-two.json")
+	policyTwoStatic, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
 	require.NoError(t, err)
 
 	// test that providing two Policies (with both different Custom rules and Managed rules) with option to only replace
@@ -64,14 +64,14 @@ func TestGeneratePolicyToRestoreBackupCustomOnly(t *testing.T) {
 }
 
 func TestGeneratePolicyToRestoreBackupManagedOnly(t *testing.T) {
-	policyOne, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-one.json")
+	policyOne, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-one.json")
 	require.NoError(t, err)
-	policyTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-two.json")
+	policyTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
 	require.NoError(t, err)
 
-	policyOneStatic, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-one.json")
+	policyOneStatic, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-one.json")
 	require.NoError(t, err)
-	policyTwoStatic, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-two.json")
+	policyTwoStatic, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
 	require.NoError(t, err)
 
 	// test that providing two Policies (with both different Custom rules and Managed rules) with option to only replace

--- a/policy/data_test.go
+++ b/policy/data_test.go
@@ -24,11 +24,11 @@ func TestParseResourceID(t *testing.T) {
 }
 
 func TestLoadWrappedPolicyFromFile(t *testing.T) {
-	wp, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-one.json")
+	wp, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-one.json")
 	require.NoError(t, err)
 	require.Equal(t, "/subscriptions/0a914e76-4921-4c19-b460-a2d36003525a/resourceGroups/flying/providers/Microsoft.Network/frontdoorWebApplicationFirewallPolicies/mypolicyone", wp.PolicyID)
 
-	_, err = LoadWrappedPolicyFromFile("testfiles/non-existant-wrapped-Policy-one.json")
+	_, err = LoadWrappedPolicyFromFile("testfiles/non-existant-wrapped-policy-one.json")
 	require.Error(t, err)
 }
 

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -63,7 +63,7 @@ func TestValidateSubscriptionID(t *testing.T) {
 }
 
 func TestMatchExistingPolicyByID(t *testing.T) {
-	wp, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-one.json")
+	wp, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-one.json")
 	require.NoError(t, err)
 
 	targetPolicyID := "/subscriptions/0a914e76-4921-4c19-b460-a2d36003525a/resourceGroups/flying/providers/Microsoft.Network/frontdoorWebApplicationFirewallPolicies/mypolicyone"
@@ -74,10 +74,10 @@ func TestMatchExistingPolicyByID(t *testing.T) {
 
 // TestGeneratePolicyPatch compares two Policies and checks that the differences match the operations:
 func TestGeneratePolicyPatch(t *testing.T) {
-	pOne, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-one.json")
+	pOne, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-one.json")
 	require.NoError(t, err)
 
-	pTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-Policy-two.json")
+	pTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
 	require.NoError(t, err)
 
 	patch, err := GeneratePolicyPatch(&GeneratePolicyPatchInput{

--- a/policy/resource_id_test.go
+++ b/policy/resource_id_test.go
@@ -1,0 +1,28 @@
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetWAFPolicyResourceID(t *testing.T) {
+	raw := "/subscriptions/0a914e76-4921-4c19-b460-a2d36003525a/resourceGroups/flying/providers/Microsoft.Network/frontdoorWebApplicationFirewallPolicies/mypolicyone"
+
+	rid, err := GetWAFPolicyResourceID(nil, GetWAFPolicyResourceIDInput{RawPolicyID: raw})
+	require.NoError(t, err)
+	require.Equal(t, "mypolicyone", rid.Name)
+
+	cfg := []byte("policy_aliases:\n  p1: " + raw + "\n")
+	path := filepath.Join(t.TempDir(), "c.yaml")
+	require.NoError(t, os.WriteFile(path, cfg, 0o600))
+
+	rid, err = GetWAFPolicyResourceID(nil, GetWAFPolicyResourceIDInput{RawPolicyID: "p1", ConfigPath: path})
+	require.NoError(t, err)
+	require.Equal(t, "mypolicyone", rid.Name)
+
+	_, err = GetWAFPolicyResourceID(nil, GetWAFPolicyResourceIDInput{RawPolicyID: "missing"})
+	require.Error(t, err)
+}

--- a/session/session.go
+++ b/session/session.go
@@ -36,11 +36,8 @@ type Session struct {
 }
 
 func createDirectory(path string) error {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		if err = os.Mkdir(path, os.ModePerm); err != nil {
-			return fmt.Errorf("failed to create backups directory %s: %s",
-				path, err.Error())
-		}
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", path, err)
 	}
 
 	return nil

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,0 +1,23 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateDirectory(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "a", "b")
+
+	require.NoError(t, createDirectory(target))
+
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+
+	// should not error if directory already exists
+	require.NoError(t, createDirectory(target))
+}


### PR DESCRIPTION
## Summary
- fix failing test paths
- simplify directory creation logic
- add tests for session directory creation
- add tests for `GetWAFPolicyResourceID`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68454fd71434832084771a59f97e08fd