### PR TITLE
Refactor restore helpers

### DIFF
--- a/policy/backup_test.go
+++ b/policy/backup_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGeneratePolicyToRestoreBackupOnly(t *testing.T) {
+func TestBuildRestoredPolicyBackupOnly(t *testing.T) {
 	policyTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
 	require.NoError(t, err)
 
@@ -15,12 +15,12 @@ func TestGeneratePolicyToRestoreBackupOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	// test that if only backup provided, that backup is returned
-	generatedPolicyOne := GeneratePolicyToRestore(&WrappedPolicy{}, &policyTwo, &RestorePoliciesInput{})
+	generatedPolicyOne := BuildRestoredPolicy(&WrappedPolicy{}, &policyTwo, &RestorePoliciesInput{})
 	require.NotNil(t, generatedPolicyOne)
 	require.True(t, reflect.DeepEqual(generatedPolicyOne.Policy, policyTwoStatic.Policy))
 }
 
-func TestGeneratePolicyToRestoreBackupWithoutOptions(t *testing.T) {
+func TestBuildRestoredPolicyBackupWithoutOptions(t *testing.T) {
 	policyOne, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-one.json")
 	require.NoError(t, err)
 	policyTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
@@ -30,12 +30,12 @@ func TestGeneratePolicyToRestoreBackupWithoutOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	// test that providing two Policies without options returns Original with backup rules replacing Original's
-	generatedPolicyTwo := GeneratePolicyToRestore(&policyOne, &policyTwo, &RestorePoliciesInput{})
+	generatedPolicyTwo := BuildRestoredPolicy(&policyOne, &policyTwo, &RestorePoliciesInput{})
 	require.NotNil(t, generatedPolicyTwo)
 	require.True(t, reflect.DeepEqual(generatedPolicyTwo.Policy, policyTwoStatic.Policy))
 }
 
-func TestGeneratePolicyToRestoreBackupCustomOnly(t *testing.T) {
+func TestBuildRestoredPolicyBackupCustomOnly(t *testing.T) {
 	policyOne, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-one.json")
 	require.NoError(t, err)
 	policyTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
@@ -48,7 +48,7 @@ func TestGeneratePolicyToRestoreBackupCustomOnly(t *testing.T) {
 
 	// test that providing two Policies (with both different Custom rules and Managed rules) with option to only replace
 	// Custom rules with backup's Custom rules
-	generatedPolicyThree := GeneratePolicyToRestore(&policyOne, &policyTwo, &RestorePoliciesInput{
+	generatedPolicyThree := BuildRestoredPolicy(&policyOne, &policyTwo, &RestorePoliciesInput{
 		CustomRulesOnly: true,
 	})
 
@@ -63,7 +63,7 @@ func TestGeneratePolicyToRestoreBackupCustomOnly(t *testing.T) {
 	require.False(t, reflect.DeepEqual(generatedPolicyThree.Policy.Properties.ManagedRules, policyTwoStatic.Policy.Properties.ManagedRules))
 }
 
-func TestGeneratePolicyToRestoreBackupManagedOnly(t *testing.T) {
+func TestBuildRestoredPolicyBackupManagedOnly(t *testing.T) {
 	policyOne, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-one.json")
 	require.NoError(t, err)
 	policyTwo, err := LoadWrappedPolicyFromFile("../testfiles/wrapped-policy-two.json")
@@ -76,7 +76,7 @@ func TestGeneratePolicyToRestoreBackupManagedOnly(t *testing.T) {
 
 	// test that providing two Policies (with both different Custom rules and Managed rules) with option to only replace
 	// Custom rules with backup's Custom rules
-	generatedPolicyThree := GeneratePolicyToRestore(&policyOne, &policyTwo, &RestorePoliciesInput{
+	generatedPolicyThree := BuildRestoredPolicy(&policyOne, &policyTwo, &RestorePoliciesInput{
 		ManagedRulesOnly: true,
 	})
 


### PR DESCRIPTION
## Summary
- clean up restore helpers
- rename GeneratePolicyToRestore -> BuildRestoredPolicy
- split restore logic into smaller functions
- update tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849f83546a48320b04bb0b4ddeed6c6