### PR TITLE
Refactor helper for function names

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -2,10 +2,9 @@ package cache
 
 import (
 	"fmt"
-	"runtime"
-	"strings"
 	"sync"
 
+	"github.com/jonhadfield/azwaf/helpers"
 	"github.com/jonhadfield/azwaf/session"
 	"github.com/sirupsen/logrus"
 	"github.com/tidwall/buntdb"
@@ -13,16 +12,8 @@ import (
 
 var m sync.Mutex
 
-func GetFunctionName() string {
-	pc, _, _, _ := runtime.Caller(1)
-	complete := runtime.FuncForPC(pc).Name()
-	split := strings.Split(complete, "/")
-
-	return split[len(split)-1]
-}
-
 func Write(sess *session.Session, key, value string) error {
-	funcName := GetFunctionName()
+	funcName := helpers.GetFunctionName()
 	logrus.Debugf("%s | writing key %s with length %d to %s", funcName, key, len(value), sess.CachePath)
 
 	m.Lock()
@@ -41,7 +32,7 @@ func Write(sess *session.Session, key, value string) error {
 
 func Read(sess *session.Session, key string) (string, error) {
 	if sess.Cache == nil {
-		return "", fmt.Errorf("%s - session cache not provided", GetFunctionName())
+		return "", fmt.Errorf("%s - session cache not provided", helpers.GetFunctionName())
 	}
 
 	var val string
@@ -54,7 +45,7 @@ func Read(sess *session.Session, key string) (string, error) {
 		return nil
 	})
 	if err == buntdb.ErrNotFound {
-		logrus.Debugf("%s | %s not found in the db", GetFunctionName(), key)
+		logrus.Debugf("%s | %s not found in the db", helpers.GetFunctionName(), key)
 		return "", nil
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -3,19 +3,19 @@ package config
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 
+	"github.com/jonhadfield/azwaf/helpers"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
 // ParseResourceID accepts an azure resource ID as a string and returns a struct instance containing the components.
 func ParseResourceID(rawID string) ResourceID {
-    components := strings.Split(rawID, "/")
-    if len(components) != resourceIDComponents {
-        return ResourceID{}
-    }
+	components := strings.Split(rawID, "/")
+	if len(components) != resourceIDComponents {
+		return ResourceID{}
+	}
 
 	return ResourceID{
 		SubscriptionID: components[2],
@@ -70,16 +70,8 @@ type FileConfig struct {
 	PolicyAliases map[string]string `yaml:"policy_aliases"`
 }
 
-func GetFunctionName() string {
-	pc, _, _, _ := runtime.Caller(1)
-	complete := runtime.FuncForPC(pc).Name()
-	split := strings.Split(complete, "/")
-
-	return split[len(split)-1]
-}
-
 func ReadFileBytes(path string) (content []byte, err error) {
-	funcName := GetFunctionName()
+	funcName := helpers.GetFunctionName()
 
 	logrus.Debugf("%s | reading %s", funcName, path)
 

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -1,0 +1,20 @@
+package helpers
+
+import (
+	"runtime"
+	"strings"
+)
+
+// callerName returns the name of the function "skip" levels up the call stack.
+func callerName(skip int) string {
+	pc, _, _, _ := runtime.Caller(skip)
+	complete := runtime.FuncForPC(pc).Name()
+	split := strings.Split(complete, "/")
+	return split[len(split)-1]
+}
+
+// GetFunctionName returns the name of the calling function.
+func GetFunctionName() string { return callerName(1) }
+
+// GetParentFunctionName returns the name of the parent of the calling function.
+func GetParentFunctionName() string { return callerName(3) }

--- a/policy/utils.go
+++ b/policy/utils.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"runtime"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor"
 
+	"github.com/jonhadfield/azwaf/helpers"
 	"github.com/ztrue/tracerr"
 )
 
@@ -69,7 +69,7 @@ func Int32ToPointer(i int32) (p *int32) {
 }
 
 func splitRuleSetName(rsName string) (rsType, rsVersion string, err error) {
-	funcName := GetFunctionName()
+	funcName := helpers.GetFunctionName()
 	if rsName == "" {
 		err = fmt.Errorf("%s - rule set name missing", funcName)
 
@@ -87,11 +87,7 @@ func splitRuleSetName(rsName string) (rsType, rsVersion string, err error) {
 }
 
 func GetFunctionName() string {
-	pc, _, _, _ := runtime.Caller(1)
-	complete := runtime.FuncForPC(pc).Name()
-	split := strings.Split(complete, "/")
-
-	return split[len(split)-1]
+	return helpers.GetParentFunctionName()
 }
 
 func toPtr[T any](v T) *T {

--- a/session/clients.go
+++ b/session/clients.go
@@ -3,22 +3,14 @@ package session
 import (
 	"errors"
 	"fmt"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"runtime"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor"
 
+	"github.com/jonhadfield/azwaf/helpers"
 	"github.com/sirupsen/logrus"
 )
-
-func GetFunctionName() string {
-	pc, _, _, _ := runtime.Caller(1)
-	complete := runtime.FuncForPC(pc).Name()
-	split := strings.Split(complete, "/")
-
-	return split[len(split)-1]
-}
 
 // GetResourcesClient creates a new resources client instance and stores it in the provided session.
 // If an authorizer instance is missing, it will make a call to create it and then store in the session also.
@@ -44,7 +36,7 @@ func (s *Session) GetResourcesClient(subID string) (err error) {
 
 	c, err := armresources.NewClient(subID, s.ClientCredential, nil)
 	if err != nil {
-		return fmt.Errorf(err.Error(), GetFunctionName())
+		return fmt.Errorf(err.Error(), helpers.GetFunctionName())
 	}
 
 	s.ResourcesClients[subID] = c
@@ -53,7 +45,7 @@ func (s *Session) GetResourcesClient(subID string) (err error) {
 }
 
 func (s *Session) GetFrontDoorPoliciesClient(subID string) (err error) {
-	funcName := GetFunctionName()
+	funcName := helpers.GetFunctionName()
 
 	if s == nil {
 		return errors.New("session is nil")
@@ -89,7 +81,7 @@ func (s *Session) GetFrontDoorPoliciesClient(subID string) (err error) {
 }
 
 func (s *Session) GetManagedRuleSetsClient(subID string) (err error) {
-	funcName := GetFunctionName()
+	funcName := helpers.GetFunctionName()
 
 	if subID == "" {
 		return fmt.Errorf("%s - subscription id is mandatory", funcName)
@@ -118,7 +110,7 @@ func (s *Session) GetManagedRuleSetsClient(subID string) (err error) {
 
 	frontDoorManagedRuleSetsClient, merr := armfrontdoor.NewManagedRuleSetsClient(subID, s.ClientCredential, nil)
 	if merr != nil {
-		return fmt.Errorf(merr.Error(), GetFunctionName())
+		return fmt.Errorf(merr.Error(), helpers.GetFunctionName())
 	}
 
 	s.FrontDoorsManagedRuleSetsClients[subID] = frontDoorManagedRuleSetsClient

--- a/session/config.go
+++ b/session/config.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jonhadfield/azwaf/helpers"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
 func ReadFileBytes(path string) (content []byte, err error) {
-	funcName := GetFunctionName()
+	funcName := helpers.GetFunctionName()
 
 	logrus.Debugf("%s | reading %s", funcName, path)
 

--- a/session/session.go
+++ b/session/session.go
@@ -2,15 +2,17 @@ package session
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/jonhadfield/azwaf/helpers"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	"github.com/tidwall/buntdb"
-	"os"
-	"path/filepath"
 )
 
 const (
@@ -44,7 +46,7 @@ func createDirectory(path string) error {
 }
 
 func (s *Session) InitialiseFilePaths() error {
-	funcName := GetFunctionName()
+	funcName := helpers.GetFunctionName()
 
 	// attempt to use home directory as working directory for cache and auto-backups
 	workingRoot, herr := homedir.Dir()
@@ -91,14 +93,14 @@ func New() *Session {
 	s := &Session{}
 
 	if err := s.InitialiseFilePaths(); err != nil {
-		logrus.Fatalf("%s | failed to initialise paths: %s", GetFunctionName(), err.Error())
+		logrus.Fatalf("%s | failed to initialise paths: %s", helpers.GetFunctionName(), err.Error())
 	}
 
 	return s
 }
 
 func (s *Session) InitialiseCache() {
-	funcName := GetFunctionName()
+	funcName := helpers.GetFunctionName()
 
 	// if we don't have a session or we do, and the cache is initialised, then return it
 	if s == nil {
@@ -156,7 +158,7 @@ func (s *Session) GetFrontDoorsClient(subID string) (c armfrontdoor.FrontDoorsCl
 
 	frontDoorsClient, merr := armfrontdoor.NewFrontDoorsClient(subID, s.ClientCredential, nil)
 	if merr != nil {
-		return c, fmt.Errorf(merr.Error(), GetFunctionName())
+		return c, fmt.Errorf(merr.Error(), helpers.GetFunctionName())
 	}
 
 	s.FrontDoorsClients[subID] = frontDoorsClient
@@ -165,7 +167,7 @@ func (s *Session) GetFrontDoorsClient(subID string) (c armfrontdoor.FrontDoorsCl
 }
 
 func (s *Session) GetClientCredential() error {
-	funcName := GetFunctionName()
+	funcName := helpers.GetFunctionName()
 
 	logrus.Debugf("getting Azure API credential")
 


### PR DESCRIPTION
## Summary
- centralize function name retrieval in new helpers package
- use helpers across packages for consistent logging

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684c97abcf9c8320ac59e02ae0f2ed49