### PR TITLE
Improve test coverage

### DIFF
--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -1,0 +1,18 @@
+package helpers
+
+import (
+    "testing"
+    "github.com/stretchr/testify/require"
+)
+
+func TestGetFunctionName(t *testing.T) {
+    // GetFunctionName is expected to return the name of itself when called
+    require.Equal(t, "helpers.GetFunctionName", GetFunctionName())
+}
+
+func callParent() string { return GetParentFunctionName() }
+
+func TestGetParentFunctionName(t *testing.T) {
+    // GetParentFunctionName should return the parent caller's name
+    require.Equal(t, "helpers.TestGetParentFunctionName", callParent())
+}

--- a/session/config_test.go
+++ b/session/config_test.go
@@ -1,0 +1,40 @@
+package session
+
+import (
+    "os"
+    "path/filepath"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+)
+
+func TestReadFileBytes(t *testing.T) {
+    base := t.TempDir()
+    path := filepath.Join(base, "f.txt")
+    data := []byte("hello")
+    require.NoError(t, os.WriteFile(path, data, 0o600))
+
+    b, err := ReadFileBytes(path)
+    require.NoError(t, err)
+    require.Equal(t, data, b)
+}
+
+func TestReadFileBytesError(t *testing.T) {
+    _, err := ReadFileBytes("/no/such/file")
+    require.Error(t, err)
+    require.Contains(t, err.Error(), "helpers.GetFunctionName")
+}
+
+func TestLoadFileConfig(t *testing.T) {
+    data := []byte("policy_aliases:\n  foo: bar\n")
+    tmp := filepath.Join(t.TempDir(), "c.yaml")
+    require.NoError(t, os.WriteFile(tmp, data, 0o600))
+
+    cfg, err := LoadFileConfig(tmp)
+    require.NoError(t, err)
+    require.Equal(t, "bar", cfg.PolicyAliases["foo"])
+
+    cfg, err = LoadFileConfig("")
+    require.NoError(t, err)
+    require.Nil(t, cfg.PolicyAliases)
+}


### PR DESCRIPTION
## Summary
- add tests for helpers functions
- add tests for session config helpers

## Testing
- `go test ./... -cover`

------
https://chatgpt.com/codex/tasks/task_e_684eaa5692148320a28ad4259c3e748e