### PR TITLE
Fix nil policy dereference

### DIFF
--- a/policy/delete_custom_rule.go
+++ b/policy/delete_custom_rule.go
@@ -186,8 +186,6 @@ func DeleteCustomRulesCLI(cliInput *DeleteCustomRulesCLIInput) (err error) {
 		return
 	}
 
-	var updatedPolicy *armfrontdoor.WebApplicationFirewallPolicy
-
 	var modified bool
 	if modified, err = DeleteCustomRulesPrefixes(DeleteCustomRulesPrefixesInput{
 		RID:         policyID,
@@ -213,7 +211,7 @@ func DeleteCustomRulesCLI(cliInput *DeleteCustomRulesCLIInput) (err error) {
 		PolicyName:       *getPolicyOutput.Policy.Name,
 		SubscriptionID:   policyID.SubscriptionID,
 		ResourceGroup:    policyID.ResourceGroup,
-		PolicyPostChange: *updatedPolicy,
+		PolicyPostChange: *getPolicyOutput.Policy,
 		DryRun:           cliInput.DryRun,
 		Debug:            dcri.Debug,
 	})


### PR DESCRIPTION
## Summary
- avoid dereferencing a nil policy when deleting custom rules

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6851f62a795c83208b9d1bbc7af3f8e2