### PR TITLE
Fix lint issues and remove code smells

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -21,7 +21,7 @@ func newTestSession(t *testing.T) *session.Session {
 
 func TestWriteRead(t *testing.T) {
 	s := newTestSession(t)
-	defer s.Cache.Close()
+	defer func() { require.NoError(t, s.Cache.Close()) }()
 
 	require.NoError(t, Write(s, "k", "v"))
 
@@ -32,7 +32,7 @@ func TestWriteRead(t *testing.T) {
 
 func TestReadMissing(t *testing.T) {
 	s := newTestSession(t)
-	defer s.Cache.Close()
+	defer func() { require.NoError(t, s.Cache.Close()) }()
 
 	v, err := Read(s, "missing")
 	require.NoError(t, err)

--- a/cmd/commands/cmdAdd.go
+++ b/cmd/commands/cmdAdd.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	. "github.com/jonhadfield/azwaf/policy"
+	policy "github.com/jonhadfield/azwaf/policy"
 )
 
 func CmdAdd(appVersion string) *cli.Command {
@@ -20,7 +20,7 @@ func CmdAdd(appVersion string) *cli.Command {
 			{
 				Name:        "exclusion",
 				UsageText:   "azwaf add exclusion [ --rule-set | --rule-group | --rule-id ] --variable=x --operator=x --selector=x [ <policy id> | <policy hash> ]",
-				Description: fmt.Sprintf("add a managed rule exclusion to a rule, rule group, or rule set\n\nMatch Variables: %s\nMatch Operators: %s", strings.Join(ValidRuleExclusionMatchVariables[:], ", "), strings.Join(ValidRuleExclusionMatchOperators[:], ", ")),
+				Description: fmt.Sprintf("add a managed rule exclusion to a rule, rule group, or rule set\n\nMatch Variables: %s\nMatch Operators: %s", strings.Join(policy.ValidRuleExclusionMatchVariables[:], ", "), strings.Join(policy.ValidRuleExclusionMatchOperators[:], ", ")),
 				Aliases:     []string{"managed"},
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
@@ -70,8 +70,8 @@ func CmdAdd(appVersion string) *cli.Command {
 						return fmt.Errorf("missing policy id / hash")
 					}
 
-					addManagedRuleExclusionCLIInput := AddManagedRuleExclusionCLIInput{
-						BaseCLIInput: BaseCLIInput{
+					addManagedRuleExclusionCLIInput := policy.AddManagedRuleExclusionCLIInput{
+						BaseCLIInput: policy.BaseCLIInput{
 							AppVersion:     appVersion,
 							AutoBackup:     c.Bool(FlagAutoBackup),
 							Debug:          c.Bool("debug"),
@@ -94,7 +94,7 @@ func CmdAdd(appVersion string) *cli.Command {
 					addManagedRuleExclusionCLIInput.AutoBackup = c.Bool(FlagAutoBackup)
 					addManagedRuleExclusionCLIInput.AppVersion = appVersion
 
-					return AddManagedRuleExclusion(&addManagedRuleExclusionCLIInput)
+					return policy.AddManagedRuleExclusion(&addManagedRuleExclusionCLIInput)
 				},
 			},
 		},

--- a/cmd/commands/cmdBackup.go
+++ b/cmd/commands/cmdBackup.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	. "github.com/jonhadfield/azwaf/policy"
+	policy "github.com/jonhadfield/azwaf/policy"
 	"github.com/urfave/cli/v2"
 )
 
@@ -18,8 +18,8 @@ func CmdBackup(versionOutput string) *cli.Command {
 		Action: func(c *cli.Context) error {
 			input := c.Args().Slice()
 
-			config := BackupPoliciesInput{
-				BaseCLIInput: BaseCLIInput{
+			config := policy.BackupPoliciesInput{
+				BaseCLIInput: policy.BaseCLIInput{
 					AppVersion:     versionOutput,
 					AutoBackup:     c.Bool(FlagAutoBackup),
 					Debug:          c.Bool("debug"),
@@ -35,7 +35,7 @@ func CmdBackup(versionOutput string) *cli.Command {
 				FailFast:                 c.Bool("fail-fast"),
 			}
 
-			return BackupPolicies(&config)
+			return policy.BackupPolicies(&config)
 		},
 	}
 }

--- a/cmd/commands/cmdCopy.go
+++ b/cmd/commands/cmdCopy.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	. "github.com/jonhadfield/azwaf/policy"
+	policy "github.com/jonhadfield/azwaf/policy"
 	"github.com/urfave/cli/v2"
 )
 
@@ -21,8 +21,8 @@ func CmdCopy(versionOutput string) *cli.Command {
 			&cli.BoolFlag{Name: "async", Usage: "push resulting policy without waiting for completion", Aliases: []string{"a"}},
 		},
 		Action: func(c *cli.Context) error {
-			copyRulesInput := CopyRulesInput{
-				BaseCLIInput: BaseCLIInput{
+			copyRulesInput := policy.CopyRulesInput{
+				BaseCLIInput: policy.BaseCLIInput{
 					AppVersion:     versionOutput,
 					AutoBackup:     c.Bool(FlagAutoBackup),
 					Debug:          c.Bool("debug"),
@@ -39,7 +39,7 @@ func CmdCopy(versionOutput string) *cli.Command {
 				Async:            c.Bool("async"),
 			}
 
-			return CopyRules(copyRulesInput)
+			return policy.CopyRules(copyRulesInput)
 		},
 	}
 }

--- a/cmd/commands/cmdDelete.go
+++ b/cmd/commands/cmdDelete.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"fmt"
 
-	. "github.com/jonhadfield/azwaf/policy"
+	policy "github.com/jonhadfield/azwaf/policy"
 	"github.com/urfave/cli/v2"
 )
 
@@ -61,7 +61,7 @@ func CmdDelete(versionOutput string) *cli.Command {
 					input := c.Args().First()
 					if input != "" {
 						// TODO: check if extended or not and allow specification of custom-rule?
-						if err := ValidateResourceID(input, false); err != nil {
+						if err := policy.ValidateResourceID(input, false); err != nil {
 							// nolint:errcheck
 							_ = cli.ShowSubcommandHelp(c)
 
@@ -69,14 +69,14 @@ func CmdDelete(versionOutput string) *cli.Command {
 						}
 
 						subID := c.String(FlagSubscriptionID)
-						if IsRIDHash(input) && subID == "" {
+						if policy.IsRIDHash(input) && subID == "" {
 							// nolint:errcheck
 							_ = cli.ShowSubcommandHelp(c)
 
 							return fmt.Errorf("using a policy hash requires a subscription id")
 						}
 
-						dmre := DeleteManagedRuleExclusionCLIInput{
+						dmre := policy.DeleteManagedRuleExclusionCLIInput{
 							SubscriptionID:        subID,
 							PolicyID:              input,
 							RuleSet:               c.String("rule-set"),
@@ -92,7 +92,7 @@ func CmdDelete(versionOutput string) *cli.Command {
 						dmre.DryRun = c.Bool(FlagDryRun)
 						dmre.AppVersion = versionOutput
 
-						return DeleteManagedRuleExclusion(&dmre)
+						return policy.DeleteManagedRuleExclusion(&dmre)
 					}
 
 					// nolint:errcheck
@@ -122,12 +122,12 @@ func CmdDelete(versionOutput string) *cli.Command {
 					input := c.Args().First()
 					if input != "" {
 						// TODO: check if extended or not and allow specification of custom-rule?
-						if err := ValidateResourceID(input, false); err != nil {
+						if err := policy.ValidateResourceID(input, false); err != nil {
 							return cli.ShowSubcommandHelp(c)
 						}
 
-						return DeleteCustomRulesCLI(&DeleteCustomRulesCLIInput{
-							BaseCLIInput: BaseCLIInput{
+						return policy.DeleteCustomRulesCLI(&policy.DeleteCustomRulesCLIInput{
+							BaseCLIInput: policy.BaseCLIInput{
 								AppVersion:     versionOutput,
 								AutoBackup:     c.Bool(FlagAutoBackup),
 								Debug:          c.Bool("debug"),

--- a/cmd/commands/cmdGet.go
+++ b/cmd/commands/cmdGet.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	. "github.com/jonhadfield/azwaf/policy"
+	policy "github.com/jonhadfield/azwaf/policy"
 	"github.com/urfave/cli/v2"
 )
 
@@ -21,7 +21,7 @@ func CmdGet() *cli.Command {
 					// get custom rule match-value field using format "<policy id>|<rule-name>"
 					input := c.Args().First()
 
-					return PrintPolicy(input, c.String(FlagSubscriptionID), c.String(FlagConfig))
+					return policy.PrintPolicy(input, c.String(FlagSubscriptionID), c.String(FlagConfig))
 				},
 			},
 			{
@@ -35,7 +35,7 @@ func CmdGet() *cli.Command {
 					// get custom rule match-value field using format "<policy id>|<rule-name>"
 					input := c.Args().First()
 
-					return PrintPolicyCustomRule(c.String(FlagSubscriptionID), input, c.String(FlagConfig))
+					return policy.PrintPolicyCustomRule(c.String(FlagSubscriptionID), input, c.String(FlagConfig))
 				},
 			},
 		},

--- a/cmd/commands/cmdList.go
+++ b/cmd/commands/cmdList.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	. "github.com/jonhadfield/azwaf/policy"
+	policy "github.com/jonhadfield/azwaf/policy"
 )
 
 func CmdList() *cli.Command {
@@ -26,7 +26,7 @@ func CmdList() *cli.Command {
 						return fmt.Errorf("subscription-id required")
 					}
 
-					return ListFrontDoors(c.String(FlagSubscriptionID))
+					return policy.ListFrontDoors(c.String(FlagSubscriptionID))
 				},
 			},
 			{
@@ -35,10 +35,10 @@ func CmdList() *cli.Command {
 				Aliases: []string{"p"},
 				Flags: []cli.Flag{
 					&cli.BoolFlag{Name: "full", Aliases: []string{"f"}, Usage: "include resource id in output"},
-					&cli.IntFlag{Name: "top", Aliases: []string{"max"}, Usage: "number of policies to list", Value: MaxPoliciesToFetch},
+					&cli.IntFlag{Name: "top", Aliases: []string{"max"}, Usage: "number of policies to list", Value: policy.MaxPoliciesToFetch},
 				},
 				Action: func(c *cli.Context) error {
-					input := ListPoliciesInput{
+					input := policy.ListPoliciesInput{
 						SubscriptionID: c.String(FlagSubscriptionID),
 						Full:           c.Bool("full"),
 						Max:            c.Int("top"),
@@ -51,7 +51,7 @@ func CmdList() *cli.Command {
 						return err
 					}
 
-					return ListPolicies(input)
+					return policy.ListPolicies(input)
 				},
 			},
 		},

--- a/cmd/commands/cmdRestore.go
+++ b/cmd/commands/cmdRestore.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	. "github.com/jonhadfield/azwaf/policy"
+	policy "github.com/jonhadfield/azwaf/policy"
 )
 
 func CmdRestore(versionOutput string) *cli.Command {
@@ -28,11 +28,11 @@ func CmdRestore(versionOutput string) *cli.Command {
 				// nolint:errcheck
 				_ = cli.ShowSubcommandHelp(c)
 
-				return fmt.Errorf("%s - backup paths are required", GetFunctionName())
+				return fmt.Errorf("%s - backup paths are required", policy.GetFunctionName())
 			}
 
-			input := &RestorePoliciesInput{
-				BaseCLIInput: BaseCLIInput{
+			input := &policy.RestorePoliciesInput{
+				BaseCLIInput: policy.BaseCLIInput{
 					AppVersion:     versionOutput,
 					AutoBackup:     c.Bool(FlagAutoBackup),
 					Debug:          c.Bool("debug"),
@@ -51,7 +51,7 @@ func CmdRestore(versionOutput string) *cli.Command {
 				FailFast:         c.Bool("fail-fast"),
 			}
 
-			return RestorePolicies(input)
+			return policy.RestorePolicies(input)
 		},
 	}
 }

--- a/cmd/commands/cmdShow.go
+++ b/cmd/commands/cmdShow.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	. "github.com/jonhadfield/azwaf/policy"
+	policy "github.com/jonhadfield/azwaf/policy"
 )
 
 func CmdShow() *cli.Command {
@@ -31,7 +31,7 @@ func CmdShow() *cli.Command {
 					&cli.BoolFlag{Name: "shadows", Usage: "show shadows", Value: false},
 				},
 				Action: func(c *cli.Context) error {
-					config := ShowPolicyInput{
+					config := policy.ShowPolicyInput{
 						ConfigPath:     c.String(FlagConfig),
 						SubscriptionID: c.String(FlagSubscriptionID),
 						PolicyID:       c.Args().First(),
@@ -51,7 +51,7 @@ func CmdShow() *cli.Command {
 						return err
 					}
 
-					return ShowPolicy(config)
+					return policy.ShowPolicy(config)
 				},
 			},
 			{
@@ -74,8 +74,8 @@ func CmdShow() *cli.Command {
 						return fmt.Errorf("policy id must be specified")
 					}
 
-					input := ShowExclusionsCLIInput{
-						BaseCLIInput: BaseCLIInput{
+					input := policy.ShowExclusionsCLIInput{
+						BaseCLIInput: policy.BaseCLIInput{
 							AutoBackup:     c.Bool(FlagAutoBackup),
 							Debug:          c.Bool("debug"),
 							ConfigPath:     c.String(FlagConfig),
@@ -93,7 +93,7 @@ func CmdShow() *cli.Command {
 						return err
 					}
 
-					return ShowExclusions(&input)
+					return policy.ShowExclusions(&input)
 				},
 			},
 		},

--- a/policy/compare.go
+++ b/policy/compare.go
@@ -44,13 +44,17 @@ func compare(original interface{}, updated []byte) (differencesFound bool, err e
 	if err != nil {
 		return false, err
 	}
-	defer os.Remove(f1)
+	defer func() {
+		_ = os.Remove(f1)
+	}()
 
 	f2, err := writeTempFile(newJSON)
 	if err != nil {
 		return false, err
 	}
-	defer os.Remove(f2)
+	defer func() {
+		_ = os.Remove(f2)
+	}()
 
 	exitCode, err := runDiff(diffBinary, f1, f2)
 	if err != nil {

--- a/policy/custom_rules.go
+++ b/policy/custom_rules.go
@@ -1165,7 +1165,6 @@ type genCustomRuleFromMatchConditionsInput struct {
 	priority                   int32
 	action                     *armfrontdoor.ActionType
 	groupBy                    []*armfrontdoor.GroupByVariable
-	enabled                    *armfrontdoor.CustomRuleEnabledState
 	namePrefix                 string
 	ruleType                   *armfrontdoor.RuleType
 	rateLimitDurationInMinutes *int32

--- a/policy/custom_rules_test.go
+++ b/policy/custom_rules_test.go
@@ -270,9 +270,9 @@ func TestTryNetStrToPrefix(t *testing.T) {
 	p, err = tryNetStrToPrefix("0.0.0.0/0")
 	require.NoError(t, err)
 	require.Equal(t, "0.0.0.0/0", p.String())
-	p, err = tryNetStrToPrefix("1.2.3.256/32")
+	_, err = tryNetStrToPrefix("1.2.3.256/32")
 	require.Error(t, err)
-	p, err = tryNetStrToPrefix("0.63.63.3.3/32")
+	_, err = tryNetStrToPrefix("0.63.63.3.3/32")
 	require.Error(t, err)
 }
 

--- a/policy/delete_custom_rule.go
+++ b/policy/delete_custom_rule.go
@@ -31,20 +31,12 @@ func customRuleMatchesNameOrPriority(mi customRuleMatchesNameOrPriorityInput, cr
 
 	// check where a priority was provided (name match isn't set)
 	if mi.prioritySet {
-		if int32(mi.priority) != *cr.Priority {
-			return true
-		}
-
-		return false
+		return int32(mi.priority) != *cr.Priority
 	}
 
 	// if regex provided then test against name
 	if mi.nameMatch != nil {
-		if !mi.nameMatch.MatchString(*cr.Name) {
-			return true
-		}
-
-		return false
+		return !mi.nameMatch.MatchString(*cr.Name)
 	}
 
 	// shouldn't have any other scenarios

--- a/policy/output.go
+++ b/policy/output.go
@@ -379,8 +379,7 @@ func getRuleConfig(groupName string, manRuleDef *armfrontdoor.ManagedRuleDefinit
 					continue
 				}
 
-				var exclusions []*armfrontdoor.ManagedRuleExclusion
-				exclusions = mrs.RuleGroupOverrides[x].Rules[y].Exclusions
+				exclusions := mrs.RuleGroupOverrides[x].Rules[y].Exclusions
 
 				var action *armfrontdoor.ActionType
 
@@ -1187,13 +1186,13 @@ func processMatchVal(s string) (result string, isURL, isIPv4, isIPv6, isGeo bool
 
 func handleGeoValue(builder *strings.Builder, val string, valsWritten *int) {
 	if *valsWritten == valsPerGeoLine {
-		if _, err := builder.WriteString(fmt.Sprintf("%s\n", val)); err != nil {
+		if _, err := fmt.Fprintf(builder, "%s\n", val); err != nil {
 			logrus.Fatalf("builder failed to write output - err: %s", err.Error())
 		}
 
 		*valsWritten = 0
 	} else {
-		if _, err := builder.WriteString(fmt.Sprintf("%s, ", val)); err != nil {
+		if _, err := fmt.Fprintf(builder, "%s, ", val); err != nil {
 			logrus.Fatalf("builder failed to write output - err: %s", err.Error())
 		}
 
@@ -1202,7 +1201,7 @@ func handleGeoValue(builder *strings.Builder, val string, valsWritten *int) {
 }
 
 func handleURLValue(builder *strings.Builder, val string, prevType *string) {
-	if _, err := builder.WriteString(fmt.Sprintf("%s\n", val)); err != nil {
+	if _, err := fmt.Fprintf(builder, "%s\n", val); err != nil {
 		logrus.Fatalf("builder failed to write string - %s", err.Error())
 	}
 
@@ -1212,7 +1211,7 @@ func handleURLValue(builder *strings.Builder, val string, prevType *string) {
 func handleIPv4Value(builder *strings.Builder, val string, prevType *string, valsWritten *int, prevLen, nextLen int) {
 	switch *prevType {
 	case "":
-		if _, err := builder.WriteString(fmt.Sprintf("%s, ", val)); err != nil {
+		if _, err := fmt.Fprintf(builder, "%s, ", val); err != nil {
 			logrus.Fatalf("builder failed to write string - %s", err.Error())
 		}
 
@@ -1222,7 +1221,7 @@ func handleIPv4Value(builder *strings.Builder, val string, prevType *string, val
 	case "ipv4":
 		switch {
 		case *valsWritten == 2:
-			if _, err := builder.WriteString(fmt.Sprintf("%s\n", val)); err != nil {
+			if _, err := fmt.Fprintf(builder, "%s\n", val); err != nil {
 				logrus.Fatalf("builder failed to write string - %s", err.Error())
 			}
 
@@ -1230,7 +1229,7 @@ func handleIPv4Value(builder *strings.Builder, val string, prevType *string, val
 
 			*prevType = ""
 		case *valsWritten == 1 && (prevLen+len(val)+nextLen) > lineLengthLimit:
-			if _, err := builder.WriteString(fmt.Sprintf("%s\n", val)); err != nil {
+			if _, err := fmt.Fprintf(builder, "%s\n", val); err != nil {
 				logrus.Fatalf("builder failed to write string - %s", err.Error())
 			}
 
@@ -1238,7 +1237,7 @@ func handleIPv4Value(builder *strings.Builder, val string, prevType *string, val
 
 			*prevType = ""
 		default:
-			if _, err := builder.WriteString(fmt.Sprintf("%s, ", val)); err != nil {
+			if _, err := fmt.Fprintf(builder, "%s, ", val); err != nil {
 				logrus.Fatalf("builder failed to write string - %s", err.Error())
 			}
 
@@ -1249,7 +1248,7 @@ func handleIPv4Value(builder *strings.Builder, val string, prevType *string, val
 	case "ipv6":
 		switch {
 		case *valsWritten == 2:
-			if _, err := builder.WriteString(fmt.Sprintf("%s\n", val)); err != nil {
+			if _, err := fmt.Fprintf(builder, "%s\n", val); err != nil {
 				logrus.Fatalf("builder failed to write string - err: %s", err.Error())
 			}
 
@@ -1257,7 +1256,7 @@ func handleIPv4Value(builder *strings.Builder, val string, prevType *string, val
 
 			*prevType = ""
 		case *valsWritten == 1 && (prevLen+len(val)+nextLen) > lineLengthLimit:
-			if _, err := builder.WriteString(fmt.Sprintf("%s\n", val)); err != nil {
+			if _, err := fmt.Fprintf(builder, "%s\n", val); err != nil {
 				logrus.Fatalf("builder failed to write string - err: %s", err.Error())
 			}
 
@@ -1265,7 +1264,7 @@ func handleIPv4Value(builder *strings.Builder, val string, prevType *string, val
 
 			*prevType = ""
 		default:
-			if _, err := builder.WriteString(fmt.Sprintf("%s, ", val)); err != nil {
+			if _, err := fmt.Fprintf(builder, "%s, ", val); err != nil {
 				logrus.Fatalf("builder failed to write string - err: %s", err.Error())
 			}
 
@@ -1281,7 +1280,7 @@ func handleIPv4Value(builder *strings.Builder, val string, prevType *string, val
 func handleIPv6Value(builder *strings.Builder, val string, prevType *string, valsWritten *int, prevLen, nextLen int) {
 	switch *prevType {
 	case "":
-		if _, err := builder.WriteString(fmt.Sprintf("%s, ", val)); err != nil {
+		if _, err := fmt.Fprintf(builder, "%s, ", val); err != nil {
 			logrus.Fatalf("builder failed to write string - err: %s", err.Error())
 		}
 
@@ -1291,7 +1290,7 @@ func handleIPv6Value(builder *strings.Builder, val string, prevType *string, val
 	case "ipv4":
 		switch {
 		case *valsWritten == 1 && (prevLen+len(val)+nextLen) > lineLengthLimit:
-			if _, err := builder.WriteString(fmt.Sprintf("%s\n", val)); err != nil {
+			if _, err := fmt.Fprintf(builder, "%s\n", val); err != nil {
 				logrus.Fatalf("builder failed to write string - err: %s", err.Error())
 			}
 
@@ -1299,7 +1298,7 @@ func handleIPv6Value(builder *strings.Builder, val string, prevType *string, val
 
 			*prevType = ""
 		case *valsWritten == 2:
-			if _, err := builder.WriteString(fmt.Sprintf("%s\n", val)); err != nil {
+			if _, err := fmt.Fprintf(builder, "%s\n", val); err != nil {
 				logrus.Fatalf("builder failed to write string - err: %s", err.Error())
 			}
 
@@ -1307,7 +1306,7 @@ func handleIPv6Value(builder *strings.Builder, val string, prevType *string, val
 
 			*prevType = ""
 		default:
-			if _, err := builder.WriteString(fmt.Sprintf("%s, ", val)); err != nil {
+			if _, err := fmt.Fprintf(builder, "%s, ", val); err != nil {
 				logrus.Fatalf("builder failed to write string - err: %s", err.Error())
 			}
 
@@ -1318,7 +1317,7 @@ func handleIPv6Value(builder *strings.Builder, val string, prevType *string, val
 	case "ipv6":
 		switch {
 		case *valsWritten == 1 && (prevLen+len(val)+nextLen) > lineLengthLimit:
-			if _, err := builder.WriteString(fmt.Sprintf("%s\n", val)); err != nil {
+			if _, err := fmt.Fprintf(builder, "%s\n", val); err != nil {
 				logrus.Fatalf("builder failed to write string - err: %s", err.Error())
 			}
 
@@ -1326,7 +1325,7 @@ func handleIPv6Value(builder *strings.Builder, val string, prevType *string, val
 
 			*prevType = ""
 		case *valsWritten == 2:
-			if _, err := builder.WriteString(fmt.Sprintf("%s\n", val)); err != nil {
+			if _, err := fmt.Fprintf(builder, "%s\n", val); err != nil {
 				logrus.Fatalf("builder failed to write string - err: %s", err.Error())
 			}
 
@@ -1334,7 +1333,7 @@ func handleIPv6Value(builder *strings.Builder, val string, prevType *string, val
 
 			*prevType = ""
 		default:
-			if _, err := builder.WriteString(fmt.Sprintf("%s, ", val)); err != nil {
+			if _, err := fmt.Fprintf(builder, "%s, ", val); err != nil {
 				logrus.Fatalf("builder failed to write string - err: %s", err.Error())
 			}
 
@@ -1383,7 +1382,7 @@ func wrapMatchValues(mvs []*string, showFull bool) string {
 			logrus.Errorf("unknown type for %s", val)
 		}
 		if i+1 == MaxMatchValuesOutput && !showFull {
-			if _, err := builder.WriteString(fmt.Sprintf("... %d remaining", len(mvs)-(i+1))); err != nil {
+			if _, err := fmt.Fprintf(&builder, "... %d remaining", len(mvs)-(i+1)); err != nil {
 				logrus.Fatalf("builder failed to write string - err: %s", err.Error())
 			}
 			break
@@ -1398,14 +1397,18 @@ func DisplayStringDiffWithDiffTool(orig, updated string) error {
 		return err
 	}
 
-	defer os.Remove(origPath.Name())
+	defer func() {
+		_ = os.Remove(origPath.Name())
+	}()
 
 	newPath, err := os.CreateTemp("", "*")
 	if err != nil {
 		return err
 	}
 
-	defer os.Remove(newPath.Name())
+	defer func() {
+		_ = os.Remove(newPath.Name())
+	}()
 
 	_, err = origPath.WriteString(orig)
 	if err != nil {

--- a/policy/policy_managed.go
+++ b/policy/policy_managed.go
@@ -563,6 +563,9 @@ func ShowManagedRuleGroupExclusions(ruleGroup string, policyID config.ResourceID
 	}
 
 	matchingDefinitions, err := getDefinitionsMatchingGroupName(s, getPolicyOutput.Policy, ruleGroup, *matchingRuleSet.RuleSetType, *matchingRuleSet.RuleSetVersion)
+	if err != nil {
+		return err
+	}
 
 	ruleGroupEx := getRuleGroupExclusionsFromRuleSet(ruleGroup, matchingRuleSet)
 
@@ -758,7 +761,7 @@ func getRuleSetDefinitions(s *session.Session, subID string) (rsds []*armfrontdo
 		return
 	}
 
-	if s.FrontDoorsManagedRuleSetDefinitions != nil && len(s.FrontDoorsManagedRuleSetDefinitions) != 0 {
+	if len(s.FrontDoorsManagedRuleSetDefinitions) != 0 {
 		logrus.Debugf("returning cached rule set definitions")
 		return s.FrontDoorsManagedRuleSetDefinitions, nil
 	}

--- a/policy/utils_test.go
+++ b/policy/utils_test.go
@@ -126,14 +126,14 @@ func copyFile(src, dst string) error {
 		return err
 	}
 
-	defer srcFile.Close()
+	defer func() { _ = srcFile.Close() }()
 
 	destFile, err := os.Create(dst) // creates if file doesn't exist
 	if err != nil {
 		return err
 	}
 
-	defer destFile.Close()
+	defer func() { _ = destFile.Close() }()
 
 	_, err = io.Copy(destFile, srcFile) // check first var for number of bytes copied
 	if err != nil {


### PR DESCRIPTION
## Summary
- clean up unused fields and error handling
- drop dot imports for clarity
- prefix policy package usages
- rewrite string formatting

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68558d4031b48320a62dee5775314cbf