### PR TITLE
Add Application Gateway WAF policy support to backup and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,476 +1,530 @@
 # azwaf
 
-A powerful command-line tool for managing Azure Web Application Firewall (WAF) policies on Azure Front Door.
+A focused command-line client for managing Azure **Front Door WAF** policies — list, inspect, copy, back up, restore, and tame managed-ruleset exclusions, all without wrestling the Azure portal. **Backup and restore** also support **Azure Application Gateway WAF** policies.
 
 [![Go Version](https://img.shields.io/github/go-mod/go-version/jonhadfield/azwaf)](https://golang.org)
 [![License](https://img.shields.io/github/license/jonhadfield/azwaf)](LICENSE)
 
-## Overview
+---
 
-`azwaf` provides a comprehensive CLI for listing, inspecting, and updating Azure Front Door WAF policies. It simplifies complex WAF management tasks with features like policy backup/restore, rule copying between policies, custom rule management, and managed ruleset exclusions.
+## Why azwaf?
 
-### Key Features
+WAF policies are notoriously fiddly to manage at scale: dozens of custom rules, sprawling managed-ruleset exclusions, no good way to diff two policies or roll one back. `azwaf` gives you a small, predictable CLI for the operations you actually do day-to-day. The bulk of the feature surface targets **Azure Front Door WAF** policies; `backup` and `restore` additionally support **Azure Application Gateway WAF** policies:
 
-- **Policy Management**: List, show, copy, and delete WAF policies
-- **Backup & Restore**: Save and restore complete policy configurations with metadata
-- **Custom Rules**: Add, update, and delete custom rules with priority enforcement
-- **Managed Rulesets**: Configure managed ruleset exclusions and settings
-- **Rule Blocking**: Block IP addresses, request URIs, and user agents
-- **Comparison**: Compare policies to identify configuration differences
-- **Caching**: BuntDB-based caching for improved performance
-- **Aliases**: Use short names instead of full Azure resource IDs
+- 🔎 **Inspect** — read policies and exclusions in a tabular form a human can scan *(Front Door)*
+- 📦 **Backup / restore** — snapshot policies to disk or Azure Blob Storage and restore them, in full or rule-by-rule *(Front Door **and** Application Gateway)*
+- 🧬 **Copy** — clone custom rules and/or managed-ruleset config from one policy onto another, with optional diff and dry-run *(Front Door)*
+- 🧹 **Surgically delete** — remove a custom rule (by name regex or priority) or a managed-rule exclusion
+- 🛡️ **Add exclusions** — at rule-set, rule-group, or rule-id scope
+- 🪪 **Friendly aliases** — refer to policies by short names from a config file, or by short content hashes
+- 🧠 **Sanity checks** — flag *shadowed* exclusions where a wider scope already covers a narrower one
+
+Built on the modern Azure SDK for Go, with cached lookups via [BuntDB](https://github.com/tidwall/buntdb) so repeated commands feel instant.
+
+---
 
 ## Table of Contents
 
-- [Overview](#overview)
 - [Installation](#installation)
 - [Configuration](#configuration)
-- [Quick Start](#quick-start)
-- [Usage](#usage)
-- [Architecture](#architecture)
-- [Development](#development)
 - [Authentication](#authentication)
+- [Quick Start](#quick-start)
+- [Command Reference](#command-reference)
+  - [Global flags](#global-flags)
+  - [`list`](#list)
+  - [`show`](#show)
+  - [`get`](#get)
+  - [`add exclusion`](#add-exclusion)
+  - [`delete`](#delete)
+  - [`backup`](#backup)
+  - [`restore`](#restore)
+  - [`copy`](#copy)
+- [Policy Aliases & Hashes](#policy-aliases--hashes)
+- [Architecture](#architecture)
+- [Limits](#limits)
+- [Development](#development)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
+- [License](#license)
+
+---
 
 ## Installation
 
 ### Prerequisites
 
-- Go 1.24+ (for building from source)
-- Azure subscription with Front Door WAF policies
-- Azure credentials configured (Azure CLI, Managed Identity, or Service Principal)
+- Go **1.24+** (only required to build from source)
+- An Azure subscription with one or more Front Door or Application Gateway WAF policies
+- Azure credentials available via Azure CLI, environment variables, managed identity, or another mechanism the [Azure Identity for Go](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication) chain supports
 
-### Build from Source
+### Build from source
 
 ```bash
-# Clone the repository
 git clone https://github.com/jonhadfield/azwaf.git
 cd azwaf
 
-# Build the binary
-make build
-
-# Install to system (macOS)
-make mac-install
-
-# Install to system (Linux)
-make linux-install
+make build           # produces .local_dist/azwaf
+make mac-install     # installs to /usr/local/bin (macOS)
+make linux-install   # installs to /usr/local/bin (Linux)
 ```
 
-The compiled binary will be available at `.local_dist/azwaf`.
-
-### Build for Multiple Platforms
+### Cross-compile
 
 ```bash
-# Build for all supported platforms
-make build-all
-
-# Build for Linux only
-make build-linux
+make build-all       # darwin/amd64, linux/amd64, linux/arm, linux/arm64, *bsd/amd64
+make build-linux     # linux/amd64 only
 ```
+
+---
 
 ## Configuration
 
-### Environment Variables
+### Environment variables
 
-- `AZURE_SUBSCRIPTION_ID` **(required)**: Azure subscription ID containing your WAF policies
-- `AZWAF_LOG`: Set to `debug` for verbose logging (default: `info`)
-- Standard Azure authentication variables:
-  - `AZURE_CLIENT_ID`
-  - `AZURE_CLIENT_SECRET`
-  - `AZURE_TENANT_ID`
+| Variable | Purpose |
+| --- | --- |
+| `AZURE_SUBSCRIPTION_ID` | Subscription containing your WAF policies. Most commands need this (or `--subscription-id`). |
+| `AZWAF_LOG` | Set to `debug` for verbose output. Default `info`. |
+| `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` | Service-principal auth (one of several supported flows). |
 
-### Configuration File
+### Config file
 
-The application looks for a configuration file at `~/.config/azwaf/config.yaml`. This file stores policy aliases for easier reference.
-
-**Example config.yaml:**
+`azwaf` looks for `~/.config/azwaf/config.yaml` by default. The file currently holds a single map: short aliases for full policy resource IDs.
 
 ```yaml
 policy_aliases:
-  prod-waf: /subscriptions/abc-123/resourceGroups/prod-rg/providers/Microsoft.Network/FrontDoorWebApplicationFirewallPolicies/prod-policy
-  staging-waf: /subscriptions/abc-123/resourceGroups/staging-rg/providers/Microsoft.Network/FrontDoorWebApplicationFirewallPolicies/staging-policy
+  prod-waf:    /subscriptions/abc-123/resourceGroups/prod-rg/providers/Microsoft.Network/FrontDoorWebApplicationFirewallPolicies/prod-policy
+  staging-waf: /subscriptions/abc-123/resourceGroups/stg-rg/providers/Microsoft.Network/FrontDoorWebApplicationFirewallPolicies/stg-policy
 ```
 
-Override the config file path with `--config`:
+Override the path with `--config /path/to/config.yaml`.
 
-```bash
-azwaf --config /path/to/config.yaml list policies
+### Working directory
+
+`azwaf` keeps cache and auto-backups under `~/.azwaf/`:
+
 ```
+~/.azwaf/
+├── cache/cache.db    # BuntDB cache for resource-id ↔ hash lookups
+└── backups/          # auto-backups written before mutating commands
+```
+
+---
+
+## Authentication
+
+`azwaf` uses [`azidentity.NewDefaultAzureCredential`](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity), so any of the following work:
+
+1. **Azure CLI** — `az login`, then run `azwaf` (great for interactive use)
+2. **Environment variables** — set `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` (great for CI/automation)
+3. **Managed identity** — when running on an Azure VM, App Service, Container App, AKS, etc.
+4. **Workload identity, Azure Developer CLI (`azd`), and other SDK-supported flows**
+
+The role assigned to your principal needs read/write on the WAF policies you intend to operate on — Front Door WAF policies, Application Gateway WAF policies, or both (`Contributor`, or a more scoped custom role).
+
+---
 
 ## Quick Start
 
 ```bash
-# Set required environment variable
-export AZURE_SUBSCRIPTION_ID="your-subscription-id"
+export AZURE_SUBSCRIPTION_ID="your-sub-id"
 
-# List all WAF policies
+# Discover what's there
 azwaf list policies
-
-# Show detailed policy information
-azwaf show policy <policy-id>
-```
-
-## Usage
-
-### List Resources
-
-```bash
-# List all WAF policies in the subscription
-azwaf list policies
-
-# List all Front Doors in the subscription
 azwaf list frontdoors
-```
 
-### Show Policy Details
-
-```bash
-# Show policy details using full resource ID
-azwaf show policy <policy-id>
-
-# Show policy using alias (from config file)
+# Inspect a policy (use the short hash printed by `list policies`, an alias, or the full resource ID)
 azwaf show policy prod-waf
+azwaf show policy prod-waf --custom-only --stats
 
-# Show policy in JSON format
-azwaf show policy prod-waf --format json
+# Look at managed-ruleset exclusions, including ones that shadow narrower scopes
+azwaf show managed-rule-exclusions prod-waf --shadows
 ```
 
-### Backup & Restore
+---
+
+## Command Reference
+
+### Global flags
+
+These are accepted by every command:
+
+| Flag | Aliases | Default | Description |
+| --- | --- | --- | --- |
+| `--subscription-id` | `-s`, `--subscription` | `$AZURE_SUBSCRIPTION_ID` | Target subscription |
+| `--config` | | `~/.config/azwaf/config.yaml` | Config file path |
+| `--quiet` | | `false` | Suppress non-essential output |
+| `--auto-backup` | | `true` | Auto-snapshot the policy to `~/.azwaf/backups/` before any mutation |
+
+---
+
+### `list`
+
+List Front Doors and policies in the subscription.
 
 ```bash
-# Backup a policy to file
-azwaf backup policy prod-waf --output prod-waf-backup.json
+azwaf list policies                  # short hashes + names
+azwaf list policies --full           # include full resource IDs
+azwaf list policies --top 50         # cap results (default 200)
 
-# Restore a policy from backup
-azwaf restore policy --input prod-waf-backup.json
-
-# Restore to a different policy
-azwaf restore policy --input backup.json --target staging-waf
+azwaf list frontdoors                # Front Doors and the policies they reference
 ```
 
-### Copy Policies
+Aliases: `list policies` ↔ `list p`, `list frontdoors` ↔ `list f`.
+
+---
+
+### `show`
+
+#### `show policy`
+
+Render a policy as readable tables.
 
 ```bash
-# Copy entire policy from source to destination
-azwaf copy policy --source prod-waf --destination staging-waf
-
-# Copy only custom rules
-azwaf copy policy --source prod-waf --destination staging-waf --custom-rules-only
-
-# Copy only managed rulesets
-azwaf copy policy --source prod-waf --destination staging-waf --managed-rules-only
+azwaf show policy prod-waf
+azwaf show policy prod-waf --custom-only        # only custom rules
+azwaf show policy prod-waf --managed-only       # only managed rulesets
+azwaf show policy prod-waf --show-full          # show all match conditions (no truncation)
+azwaf show policy prod-waf --stats              # rule counts and summary stats
+azwaf show policy prod-waf --shadows            # highlight rules that shadow each other
 ```
 
-### Custom Rules Management
+#### `show managed-rule-exclusions`
 
-`azwaf` automatically assigns rule priorities based on action type to ensure proper evaluation order:
-
-| Action | Priority Range | Purpose |
-|--------|----------------|---------|
-| Log | 1000-1999 | Observability without blocking |
-| Allow | 3000-3999 | Explicit permits (bypass blocks) |
-| Block | 5000-5999 | Security enforcement |
-
-**Priority Assignment**: Rules are automatically assigned the next available priority in their range. Lower numbers evaluate first.
+Inspect exclusions across rule-set / rule-group / rule scope.
 
 ```bash
-# Add a custom rule to block an IP address
-azwaf add custom-rule prod-waf \
-  --name "BlockMaliciousIP" \
-  --action Block \
-  --rule-type MatchRule \
-  --match-variable RemoteAddr \
-  --operator IPMatch \
-  --match-values "192.168.1.100,10.0.0.50"
-
-# Add a rate limit rule
-azwaf add custom-rule prod-waf \
-  --name "RateLimit" \
-  --action Block \
-  --rule-type RateLimitRule \
-  --rate-limit-threshold 100 \
-  --rate-limit-duration-minutes 1
-
-# Delete a custom rule
-azwaf delete custom-rule prod-waf --name "BlockMaliciousIP"
+azwaf show managed-rule-exclusions prod-waf
+azwaf show managed-rule-exclusions prod-waf --rule-set Microsoft_DefaultRuleSet_2.1
+azwaf show managed-rule-exclusions prod-waf --rule-group SQLI
+azwaf show managed-rule-exclusions prod-waf --rule-id 942100
+azwaf show managed-rule-exclusions prod-waf --shadows   # exclusions made redundant by a wider scope
 ```
 
-### Managed Ruleset Exclusions
+Aliases: `m`, `managed`, `exclusions`, `exclusion`.
+
+---
+
+### `get`
+
+Print the raw policy payload — useful when piping into `jq`, diffing, or inspecting a specific custom rule.
 
 ```bash
-# Add exclusions to a managed ruleset
+azwaf get policy prod-waf | jq '.properties.customRules.rules[].name'
+
+# Custom-rule format is "<policy>|<rule-name>"
+azwaf get custom-rule "prod-waf|BlockBadActor"
+azwaf get custom-rule "prod-waf|BlockBadActor" --output rule.json
+```
+
+Aliases: `get policy` ↔ `get p`, `get custom-rule` ↔ `get c`.
+
+---
+
+### `add exclusion`
+
+Add a managed-rule exclusion at rule-set, rule-group, or rule-id scope. Pick **one** of `--rule-set`, `--rule-group`, `--rule-id`.
+
+| Flag | Aliases | Required | Description |
+| --- | --- | --- | --- |
+| `--match-variable` | `-v`, `--variable` | yes | One of `RequestCookieNames`, `RequestHeaderNames`, `QueryStringArgNames`, `RequestBodyPostArgNames`, `RequestBodyJsonArgNames` |
+| `--match-operator` | `-o`, `--operator` | yes | One of `Contains`, `EndsWith`, `Equals`, `EqualsAny`, `StartsWith` |
+| `--match-selector` | `-s`, `--selector` | yes | The selector value (e.g. cookie or header name) |
+| `--rule-set` | `-r` | one of three | Format: `<type>_<version>`, e.g. `Microsoft_DefaultRuleSet_2.1` |
+| `--rule-group` | `-g` | one of three | E.g. `SQLI` |
+| `--rule-id` | `-i` | one of three | E.g. `942100` |
+| `--dry-run` | `-d` | no | Compute changes but do not push |
+| `--show-diff` | | no | Print a diff between the current and proposed policy |
+
+```bash
+# Exclude the User-Agent header from a whole rule-set
 azwaf add exclusion prod-waf \
-  --rule-set "Microsoft_DefaultRuleSet" \
-  --match-variable "RequestHeaderNames" \
-  --selector "User-Agent" \
-  --operator "Equals"
+  --rule-set Microsoft_DefaultRuleSet_2.1 \
+  --variable RequestHeaderNames \
+  --operator Equals \
+  --selector User-Agent
 
-# Add exclusion to specific rule group
+# Exclude session cookies from a single rule, dry-run with diff
 azwaf add exclusion prod-waf \
-  --rule-group "PROTOCOL-ENFORCEMENT" \
-  --match-variable "RequestCookieNames" \
-  --selector "session" \
-  --operator "StartsWith"
-
-# Add exclusion to specific rule ID
-azwaf add exclusion prod-waf \
-  --rule-id "942100" \
-  --match-variable "QueryStringArgNames" \
-  --selector "search" \
-  --operator "Equals"
+  --rule-id 942100 \
+  --variable RequestCookieNames \
+  --operator StartsWith \
+  --selector session \
+  --dry-run --show-diff
 ```
 
-### Quick Block Commands
+---
 
-Convenience commands to quickly block common threat patterns:
+### `delete`
+
+#### `delete custom-rule`
+
+Delete custom rules by **name** (regex) or **priority**. At least one is required.
 
 ```bash
-# Block specific IP addresses
-azwaf add block prod-waf --ip "192.168.1.100,10.0.0.50"
-
-# Block request URIs (paths)
-azwaf add block prod-waf --uri "/admin,/wp-admin"
-
-# Block user agents
-azwaf add block prod-waf --user-agent "BadBot,MaliciousScanner"
+azwaf delete custom-rule prod-waf --name "^Block.*"        # regex match
+azwaf delete custom-rule prod-waf --priority 5100
+azwaf delete custom-rule prod-waf --name "Tmp_.*" --dry-run
 ```
 
-**Note**: These commands create custom block rules with appropriate priorities (5000-5999 range).
+Aliases: `c`, `cr`.
 
-### Compare Policies
+#### `delete managed-rule-exclusion`
+
+Mirror of `add exclusion` — same scope and match flags, same `--dry-run` / `--show-diff`.
 
 ```bash
-# Compare two policies and show differences
-azwaf compare --source prod-waf --destination staging-waf
-
-# Output comparison in JSON format
-azwaf compare --source prod-waf --destination staging-waf --format json
+azwaf delete managed-rule-exclusion prod-waf \
+  --rule-set Microsoft_DefaultRuleSet_2.1 \
+  --variable RequestHeaderNames \
+  --operator Equals \
+  --selector User-Agent \
+  --show-diff
 ```
 
-### Delete Policy
+Aliases: `m`, `mre`, `exclusion`.
+
+---
+
+### `backup`
+
+Snapshot one or more policies to disk and/or Azure Blob Storage. Policy IDs (or hashes / aliases) are positional arguments. Both **Front Door** and **Application Gateway** WAF policies are supported; the resource type embedded in each resource ID determines which API the policy is fetched from. Running with no positional arguments backs up every WAF policy of either type in the subscription.
 
 ```bash
-# Delete a WAF policy (with confirmation prompt)
-azwaf delete policy prod-waf
+# All Front Door + Application Gateway WAF policies in the subscription
+azwaf backup --path ./backups/
 
-# Force delete without confirmation
-azwaf delete policy prod-waf --force
+# Mix and match — pass full resource IDs for either type, or use FD aliases
+azwaf backup prod-waf \
+  /subscriptions/abc-123/resourceGroups/agw-rg/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/prod-agw \
+  --path ./backups/
+
+# Push to a Blob container (alongside or instead of local disk)
+azwaf backup prod-waf \
+  --container-url https://myacc.blob.core.windows.net/waf-backups
+
+# Or via storage-account resource ID (azwaf will resolve it)
+azwaf backup prod-waf \
+  --storage-account-id /subscriptions/.../storageAccounts/myacc
+
+azwaf backup prod-waf staging-waf --path ./backups/ --fail-fast
 ```
+
+| Flag | Aliases | Description |
+| --- | --- | --- |
+| `--path` | `-p` | Local directory for backup files |
+| `--container-url` | `-c` | Blob container URL to upload to |
+| `--storage-account-id` | `-s` | Storage-account resource ID (alternative to `--container-url`) |
+| `--fail-fast` | `-f` | Stop on the first error rather than continuing |
+
+> Mutating commands also create an auto-backup under `~/.azwaf/backups/` unless `--auto-backup=false` is set.
+
+> Each backup file embeds a `WAFType` field (`FrontDoor` or `ApplicationGateway`) so `restore` can dispatch to the right API. Backup files produced by older versions of `azwaf` (no `WAFType` field) are treated as Front Door for backward compatibility.
+
+---
+
+### `restore`
+
+Restore one or more backup files. Backup paths are positional. Both **Front Door** and **Application Gateway** WAF backups are accepted — each file's embedded `WAFType` field decides which API the restore is pushed through. You can mix backups of either type in a single invocation.
+
+```bash
+# Restore each backup, recreating the policy in its original resource group
+azwaf restore ./backups/prod-waf-2026-05-04.json
+
+# Restore custom rules only, on top of an existing target policy
+azwaf restore ./backups/prod-waf-2026-05-04.json \
+  --target staging-waf --custom-rules
+
+# Restore managed-rule config only
+azwaf restore ./backups/prod-waf-2026-05-04.json \
+  --target staging-waf --managed-rules --show-diff
+
+# Restore an Application Gateway WAF backup onto an existing AppGW WAF policy
+azwaf restore ./backups/prod-agw-2026-05-04.json \
+  --target /subscriptions/abc-123/resourceGroups/agw-rg/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/staging-agw \
+  --show-diff
+
+# Recreate into a different resource group, no prompt
+azwaf restore ./backups/*.json --resource-group restored-rg --force
+```
+
+| Flag | Aliases | Description |
+| --- | --- | --- |
+| `--target` | `-t` | Restore on top of an existing target policy instead of recreating |
+| `--resource-group` | `-r` | RG to restore new policies into (when not using `--target`) |
+| `--custom-rules` | `--custom`, `-c` | Restore only custom rules |
+| `--managed-rules` | `--managed`, `-m` | Restore only managed-ruleset config |
+| `--show-diff` | `-s` | Show the diff before applying |
+| `--dry-run` | `-d` | Compute the result but do not push |
+| `--force` | | Skip the confirmation prompt |
+| `--fail-fast` | `-f` | Stop on the first error |
+
+> When `--target` is used with an Application Gateway WAF backup, the target must be a full Azure resource ID — short hashes are Front Door-only (the hash cache is populated from `list policies`, which only enumerates Front Door WAFs).
+
+---
+
+### `copy`
+
+Copy custom and/or managed rules from one policy onto another. Both `--source` and `--target` are required. Hashes can be used when both policies are in the current subscription.
+
+```bash
+azwaf copy --source prod-waf --target staging-waf
+azwaf copy --source prod-waf --target staging-waf --custom-rules --show-diff
+azwaf copy --source prod-waf --target staging-waf --managed-rules --dry-run
+azwaf copy --source prod-waf --target dr-waf --async
+```
+
+| Flag | Aliases | Description |
+| --- | --- | --- |
+| `--source` | `-s`, `--src` | Source policy resource ID, alias, or hash |
+| `--target` | `-t` | Target policy resource ID, alias, or hash |
+| `--custom-rules` | `--custom`, `-c` | Copy only custom rules |
+| `--managed-rules` | `--managed`, `-m` | Copy only managed-ruleset config |
+| `--show-diff` | `--show`, `--diff` | Show the diff before applying |
+| `--dry-run` | `-d` | Generate the policy but do not push |
+| `--async` | `-a` | Push without waiting for completion |
+
+> Default behaviour copies **both** custom and managed rules. Use the flags above to scope it down.
+
+---
+
+## Policy Aliases & Hashes
+
+You can refer to a policy in three ways:
+
+1. **Full resource ID** — `/subscriptions/.../FrontDoorWebApplicationFirewallPolicies/prod-policy`
+2. **Alias** — a short name from `~/.config/azwaf/config.yaml` (e.g. `prod-waf`)
+3. **Hash** — the short string printed in `azwaf list policies`. Hashes are scoped to the current subscription, so `--subscription-id` (or `AZURE_SUBSCRIPTION_ID`) must be set when using them.
+
+---
 
 ## Architecture
-
-### Project Structure
 
 ```
 azwaf/
 ├── cmd/
-│   ├── azwaf/           # Main entry point
-│   └── commands/        # CLI command implementations
-├── policy/              # Core WAF policy logic
-│   ├── policy.go        # Main types and interfaces
-│   ├── custom_rules.go  # Custom rule management
-│   ├── policy_managed.go # Managed ruleset operations
-│   ├── backup.go        # Backup functionality
-│   ├── restore.go       # Restore functionality
-│   ├── data.go          # Data structures and marshaling
-│   └── output.go        # CLI output formatting
-├── session/             # Azure authentication and client management
-│   ├── session.go       # Session handling
-│   ├── clients.go       # Azure SDK client initialization
-│   └── config.go        # Session configuration
-├── config/              # Application configuration
-│   ├── config.go        # Config file parsing
-│   └── constants.go     # Application-wide constants
-├── cache/               # BuntDB caching for API responses
-└── helpers/             # Shared utility functions
+│   ├── azwaf/             # main(), CLI bootstrap
+│   └── commands/          # urfave/cli subcommands (add, backup, copy, …)
+├── policy/                # core WAF logic
+│   ├── policy.go          # types, fetch helpers, hashmap (Front Door)
+│   ├── custom_rules.go    # custom-rule manipulation
+│   ├── policy_managed.go  # managed-ruleset & exclusion handling
+│   ├── add_exclusions.go  # add managed-rule exclusion flow
+│   ├── delete_*.go        # delete custom rule / managed exclusion
+│   ├── backup.go          # local + blob backups (FD + AppGW)
+│   ├── restore.go         # restore flows (dispatches FD vs AppGW)
+│   ├── appgw.go           # Application Gateway WAF SDK wrappers
+│   ├── appgw_restore.go   # AppGW restore pipeline
+│   ├── copy.go            # cross-policy copy
+│   ├── compare.go         # diff helper used by --show-diff
+│   ├── show.go / output.go / stats.go  # CLI rendering
+│   └── frontdoor.go       # Front Door listing
+├── session/               # azidentity + Azure SDK clients + cache wiring
+├── config/                # config.yaml parsing, resource-ID parsing
+├── cache/                 # BuntDB-backed caching (resource-id hash map, etc.)
+└── helpers/               # shared utilities
 ```
 
-### Key Design Patterns
+### Design notes
 
-1. **Session-based Architecture**: All Azure operations go through a centralized session that manages authentication and caching
-2. **Policy Wrapper Pattern**: Policies are wrapped with metadata (`WrappedPolicy`) for backup/restore operations
-3. **Resource ID Abstraction**: Uses aliases from config file to map short names to full Azure resource IDs
-4. **Custom Rule Priorities**: Enforces ordering to ensure proper rule evaluation
+- **Session is the seam.** Every Azure-touching code path runs through a `*session.Session` that owns credentials, the SDK clients, and the cache. Tests mock at this boundary.
+- **Wrapped policies.** `WrappedPolicy` (Front Door) and `WrappedAppGWPolicy` (Application Gateway) decorate the SDK types with metadata (subscription, resource group, name, hashes, `WAFType`) so backup/restore/copy stay unambiguous about *which* policy a payload belongs to.
+- **WAF type discrimination.** `BackupPolicies` partitions inbound resource IDs into Front Door and Application Gateway lists by inspecting the resource type segment of each ID. `RestorePolicies` peeks at every backup file's `WAFType` field and routes it to the matching restore pipeline.
+- **Hash-based shorthand.** A subscription-scoped hash map (`WAFResourceIDHashMap`) lets the CLI accept short hashes in place of full resource IDs.
+- **Diffing via `diff(1)`.** `--show-diff` shells out to the system `diff` for human-readable output rather than a custom JSON differ.
 
-### Azure WAF Limits
+---
 
-These limits are enforced by Azure Front Door WAF service:
+## Limits
 
-| Resource | Limit | Notes |
-|----------|-------|-------|
-| Custom rules per policy | 90 | Hard limit enforced by Azure |
-| IP match values per rule | 600 | Per match condition |
-| Policies per fetch | 200 | Tool optimization limit |
-| Front Doors per fetch | 100 | Tool optimization limit |
+The limits below apply to Front Door WAF policies. Application Gateway WAF policies are subject to a separate set of Azure limits — `azwaf` does not enforce or surface them.
 
-For more details, see [Azure Front Door limits](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-front-door-standard-and-premium-tier-service-limits).
+| Resource | Limit | Source |
+| --- | --- | --- |
+| Custom rules per policy | **90** | Azure hard limit |
+| IP-match values per rule | **600** | Azure hard limit |
+| Conditions per custom rule | **10** | Azure hard limit |
+| Exclusions per scope | **100** (warns at 95) | Azure hard limit |
+| Policies fetched per `list policies` | **200** (configurable via `--top`) | Tool default |
+| Front Doors fetched per `list frontdoors` | **100** | Tool default |
+
+See [Azure Front Door service limits](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-front-door-standard-and-premium-tier-service-limits) for the Front Door upstream specifics, and [Application Gateway service limits](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#application-gateway-limits) for Application Gateway.
+
+---
 
 ## Development
 
-### Running Tests
-
 ```bash
-# Run unit tests with coverage
-make test
-
-# Run integration tests (requires Azure credentials)
-make test.integration
-
-# Generate and view coverage report
-make coverage
-
-# Run a specific test
-go test -v ./policy -run TestSpecificFunction
+make fmt              # goimports + gofumpt
+make lint             # golangci-lint
+make test             # unit tests with coverage
+make test.integration # integration tests (require live Azure creds)
+make coverage         # opens HTML coverage report
+make ci               # lint + test (run before pushing)
+make gosec            # security scanner
+make critic           # gocritic
 ```
 
-### Code Quality
+Unit tests mock the Azure SDK clients. Integration tests sit behind build tags and need a real subscription. Test fixtures (sample policies, IP lists) live in `policy/testdata/`.
 
-```bash
-# Format code
-make fmt
-
-# Run linter
-make lint
-
-# Run security analysis
-make gosec
-
-# Run code critic
-make critic
-
-# Run all checks (pre-commit)
-make ci
-```
-
-### Testing Strategy
-
-The project uses a multi-layered testing approach:
-
-- **Unit tests**: Mocked Azure clients for fast, isolated component testing
-- **Integration tests**: Real Azure credentials required, gated with build tags for optional execution
-- **Test fixtures**: Sample policies and IP lists in `policy/testdata/` for reproducible testing
-- **Coverage tracking**: Automated coverage reports generated via `make coverage`
-
-## Authentication
-
-`azwaf` supports all standard Azure SDK authentication methods, tried in the following order:
-
-### 1. Environment Variables (Recommended for Automation)
-
-```bash
-export AZURE_TENANT_ID="your-tenant-id"
-export AZURE_CLIENT_ID="your-client-id"
-export AZURE_CLIENT_SECRET="your-client-secret"
-export AZURE_SUBSCRIPTION_ID="your-subscription-id"
-```
-
-### 2. Azure CLI (Recommended for Interactive Use)
-
-```bash
-az login
-export AZURE_SUBSCRIPTION_ID="your-subscription-id"
-azwaf list policies
-```
-
-### 3. Managed Identity (For Azure Resources)
-
-Automatically detected when running on Azure VMs, App Service, Azure Functions, etc. No additional configuration required beyond setting `AZURE_SUBSCRIPTION_ID`.
-
-### 4. Other Methods
-
-The tool supports additional Azure SDK authentication methods including Azure Developer CLI (`azd`), workload identity, and more. See the [Azure Identity documentation](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication) for details.
+---
 
 ## Troubleshooting
 
-### Enable Debug Logging
-
-For detailed operation logs and API call tracing:
+**Verbose logs**
 
 ```bash
-export AZWAF_LOG=debug
-azwaf list policies
+AZWAF_LOG=debug azwaf list policies
 ```
 
-### Common Issues
+**“subscription-id required” / auth errors**
 
-#### Authentication Errors
+```bash
+echo $AZURE_SUBSCRIPTION_ID         # is it set?
+az account show                     # is the CLI logged in?
+az account list --query "[].id"     # do you have access?
+```
 
-**Symptoms**: "authentication failed" or "unauthorized" errors
+Make sure your principal has at least `Contributor` (or equivalent custom role) on the policies you’re touching.
 
-**Solutions**:
-- Ensure `AZURE_SUBSCRIPTION_ID` is set: `echo $AZURE_SUBSCRIPTION_ID`
-- Verify Azure credentials are configured: `az account show` or check environment variables
-- Confirm subscription access: `az account list --query "[].id"`
-- Check required permissions: Contributor or WAF Policy Contributor role on subscription/resource group
+**Stale or weird cached lookups**
 
-#### Policy Not Found
+The cache lives at `~/.azwaf/cache/cache.db` and stores resource-id ↔ hash mappings. If the contents of your subscription have changed and `azwaf` looks confused, clearing it is safe:
 
-**Symptoms**: "policy not found" or "resource does not exist"
+```bash
+rm -rf ~/.azwaf/cache/
+```
 
-**Solutions**:
-- List available policies: `azwaf list policies`
-- Verify alias configuration in `~/.config/azwaf/config.yaml`
-- Try using full resource ID instead of alias
-- Confirm policy is in the correct subscription
+**Hash not found**
 
-#### Cache Issues
+Hashes are scoped to a subscription. Confirm `--subscription-id` (or `AZURE_SUBSCRIPTION_ID`) matches the subscription where the policy lives, or pass the alias / full resource ID instead.
 
-**Symptoms**: Stale data or outdated policy information
-
-**Solutions**:
-- Clear cache directory: `rm -rf ~/.cache/azwaf/`
-- Cache automatically expires after 15 minutes
-- Use `--no-cache` flag (if available) to bypass cache
-
-#### Performance Issues
-
-**Symptoms**: Slow API responses or timeouts
-
-**Solutions**:
-- Enable caching to reduce API calls
-- Check Azure service health: https://status.azure.com
-- Reduce concurrent operations if hitting rate limits
-- Use specific policy IDs instead of listing all policies
+---
 
 ## Contributing
 
-Contributions are welcome! Please:
+Pull requests welcome. Please:
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+1. Fork and create a feature branch (`git checkout -b feature/your-thing`)
+2. Add tests for any new behaviour
+3. Run `make ci` before pushing
+4. Open a PR with a description of the change and its motivation
 
-### Development Guidelines
+Issues and feature requests: <https://github.com/jonhadfield/azwaf/issues>.
 
-- Follow Go best practices and idioms
-- Add unit tests for new functionality
-- Update documentation for user-facing changes
-- Run `make ci` before committing to ensure code quality
+---
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+MIT — see [LICENSE](LICENSE).
 
-## Support
+---
 
-For issues, questions, or feature requests, please [open an issue](https://github.com/jonhadfield/azwaf/issues) on GitHub.
+## Built with
 
-## Related Projects
-
-- [Azure Front Door Documentation](https://learn.microsoft.com/en-us/azure/frontdoor/)
-- [Azure WAF Documentation](https://learn.microsoft.com/en-us/azure/web-application-firewall/)
-- [Azure SDK for Go](https://github.com/Azure/azure-sdk-for-go)
-
-## Acknowledgments
-
-Built with:
-- [Azure SDK for Go](https://github.com/Azure/azure-sdk-for-go) - Azure resource management
-- [urfave/cli](https://github.com/urfave/cli) - CLI framework
-- [BuntDB](https://github.com/tidwall/buntdb) - Embedded key/value database for caching
-- [logrus](https://github.com/sirupsen/logrus) - Structured logging
-- [simpletable](https://github.com/alexeyco/simpletable) - Table formatting for output
-- [jsondiff](https://github.com/wI2L/jsondiff) - JSON comparison for policy diffs
+- [Azure SDK for Go](https://github.com/Azure/azure-sdk-for-go) — `armfrontdoor`, `armnetwork`, `armresources`, `azidentity`
+- [urfave/cli](https://github.com/urfave/cli) — CLI framework
+- [BuntDB](https://github.com/tidwall/buntdb) — embedded key/value cache
+- [logrus](https://github.com/sirupsen/logrus) + [nested-logrus-formatter](https://github.com/antonfisher/nested-logrus-formatter) — logging
+- [simpletable](https://github.com/alexeyco/simpletable) — table rendering
+- [jsondiff](https://github.com/wI2L/jsondiff) — structured JSON diffing

--- a/cmd/azwaf/main.go
+++ b/cmd/azwaf/main.go
@@ -70,7 +70,7 @@ func main() {
 		},
 	}
 	app.HelpName = ""
-	app.Description = "azwaf is a client for managing Azure Front Door WAF policies.\n\nwaf policy ids can be substituted for shorter \"hashes\" that can\nbe found by running: 'azwaf list policies'"
+	app.Description = "azwaf is a client for managing Azure WAF policies.\n\nFront Door WAF policies are supported across all commands. Application\nGateway WAF policies are supported by 'backup' and 'restore' only.\n\nwaf policy ids can be substituted for shorter \"hashes\" that can\nbe found by running: 'azwaf list policies'"
 	app.Usage = "azwaf [global options] command [command options] [arguments...]"
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ func ParseResourceID(rawID string) ResourceID {
 		SubscriptionID: components[2],
 		ResourceGroup:  components[4],
 		Provider:       components[6],
+		ResourceType:   components[7],
 		Name:           components[8],
 		Raw:            rawID,
 	}
@@ -45,6 +46,7 @@ type ResourceID struct {
 	SubscriptionID string
 	ResourceGroup  string
 	Provider       string
+	ResourceType   string
 	Name           string
 	Raw            string
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor v1.4.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7 v7.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0 h1:2qsI
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0/go.mod h1:AW8VEadnhw9xox+VaVd9sP7NjzOAnaZBLRH6Tq3cJ38=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0 h1:pPvTJ1dY0sA35JOeFq6TsY2xj6Z85Yo23Pj4wCCvu4o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0/go.mod h1:mLfWfj8v3jfWKsL9G4eoBoXVcsqcIUTapmdKy7uGOp0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7 v7.2.0 h1:DgqO2jYgDEqmN8W5sPP+ZU7Tfxyn+i9RqXtNsX6Enb8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7 v7.2.0/go.mod h1:FBChJszHNRdH5AYJ+Y/NgWilJihKa5WcSlFrNnj2eY0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -1,18 +1,18 @@
 package helpers
 
 import (
-    "testing"
-    "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestGetFunctionName(t *testing.T) {
-    // GetFunctionName is expected to return the name of itself when called
-    require.Equal(t, "helpers.GetFunctionName", GetFunctionName())
+	// GetFunctionName is expected to return the name of itself when called
+	require.Equal(t, "helpers.GetFunctionName", GetFunctionName())
 }
 
 func callParent() string { return GetParentFunctionName() }
 
 func TestGetParentFunctionName(t *testing.T) {
-    // GetParentFunctionName should return the parent caller's name
-    require.Equal(t, "helpers.TestGetParentFunctionName", callParent())
+	// GetParentFunctionName should return the parent caller's name
+	require.Equal(t, "helpers.TestGetParentFunctionName", callParent())
 }

--- a/policy/appgw.go
+++ b/policy/appgw.go
@@ -1,0 +1,272 @@
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
+	"github.com/jonhadfield/azwaf/config"
+	"github.com/jonhadfield/azwaf/session"
+	"github.com/sirupsen/logrus"
+	"github.com/wI2L/jsondiff"
+)
+
+// WAF policy resource type constants. These are the value of the 8th component
+// (index 7) of an Azure resource ID and are used to discriminate between
+// Front Door and Application Gateway WAF policies.
+const (
+	ResourceTypeFrontDoorWAF = "frontdoorWebApplicationFirewallPolicies"
+	ResourceTypeAppGWWAF     = "ApplicationGatewayWebApplicationFirewallPolicies"
+
+	// WAFType values written into backup files so restore can dispatch to
+	// the correct API. Empty / missing == FrontDoor for backward compatibility
+	// with backups produced by older versions.
+	WAFTypeFrontDoor = "FrontDoor"
+	WAFTypeAppGW     = "ApplicationGateway"
+
+	appGWPolicyGetTimeout = 120 * time.Second
+)
+
+// WAFTypeFromResourceID returns WAFTypeAppGW or WAFTypeFrontDoor based on the
+// resource type embedded in the resource id. Comparison is case-insensitive
+// because Azure occasionally returns resource ids with inconsistent casing.
+func WAFTypeFromResourceID(rawID string) string {
+	rid := config.ParseResourceID(rawID)
+
+	if strings.EqualFold(rid.ResourceType, ResourceTypeAppGWWAF) {
+		return WAFTypeAppGW
+	}
+
+	return WAFTypeFrontDoor
+}
+
+// WrappedAppGWPolicy is the AppGW analogue of WrappedPolicy and uses the same
+// JSON shape so existing storage/file plumbing can be reused.
+type WrappedAppGWPolicy struct {
+	Date           time.Time
+	SubscriptionID string
+	ResourceGroup  string
+	Name           string
+	Policy         armnetwork.WebApplicationFirewallPolicy
+	PolicyID       string
+	AppVersion     string
+	WAFType        string
+}
+
+// GetRawAppGWPolicy retrieves a single Application Gateway WAF policy.
+func GetRawAppGWPolicy(s *session.Session, subscription, resourceGroup, name string) (*armnetwork.WebApplicationFirewallPolicy, error) {
+	funcName := GetFunctionName()
+
+	if err := s.GetAppGWPoliciesClient(subscription); err != nil {
+		return nil, fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	logrus.Debugf("%s | getting AppGW WAF policy %s in subscription %s resource group %s",
+		funcName, name, subscription, resourceGroup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), appGWPolicyGetTimeout)
+	defer cancel()
+
+	resp, merr := s.AppGWPoliciesClients[subscription].Get(ctx, resourceGroup, name, nil)
+	if merr != nil {
+		// wrap, don't flatten: isAppGWNotFound needs the *azcore.ResponseError
+		// to remain in the chain
+		return nil, fmt.Errorf("%s - %w", funcName, merr)
+	}
+
+	return &resp.WebApplicationFirewallPolicy, nil
+}
+
+// GetAllAppGWPolicies lists every Application Gateway WAF policy in the
+// subscription, optionally filtered by FilterResourceIDs.
+func GetAllAppGWPolicies(s *session.Session, i GetWrappedPoliciesInput) ([]armnetwork.WebApplicationFirewallPolicy, error) {
+	funcName := GetFunctionName()
+
+	if err := s.GetAppGWPoliciesClient(i.SubscriptionID); err != nil {
+		return nil, fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	ctx := context.Background()
+
+	top := i.Max
+	if top == 0 {
+		top = MaxPoliciesToFetch
+	}
+
+	logrus.Debugf("listing first %d AppGW WAF policies in subscription: %s", top, i.SubscriptionID)
+
+	pager := s.AppGWPoliciesClients[i.SubscriptionID].NewListAllPager(nil)
+
+	var gres []armnetwork.WebApplicationFirewallPolicy
+
+	var total int
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("%s failed to advance page of AppGW WAF policies - %w", funcName, err)
+		}
+
+		for _, resource := range page.Value {
+			if resource.ID == nil {
+				return nil, fmt.Errorf("%s | Azure returned an AppGW WAF Policy without a resource ID: %+v", funcName, resource)
+			}
+
+			if len(i.FilterResourceIDs) == 0 || slices.Contains(i.FilterResourceIDs, *resource.ID) {
+				gres = append(gres, *resource)
+			}
+
+			total++
+
+			if total == top {
+				return gres, nil
+			}
+		}
+	}
+
+	logrus.Debugf("retrieved %d AppGW WAF resources", total)
+
+	return gres, nil
+}
+
+// GetWrappedAppGWPoliciesFromRawIDs mirrors GetWrappedPoliciesFromRawIDs but
+// for AppGW. Filter resource ids must already be parsed AppGW WAF policy ids.
+func GetWrappedAppGWPoliciesFromRawIDs(s *session.Session, i GetWrappedPoliciesInput) ([]WrappedAppGWPolicy, error) {
+	funcName := GetFunctionName()
+
+	var rids []config.ResourceID
+
+	if len(i.FilterResourceIDs) > 0 {
+		for _, rawID := range i.FilterResourceIDs {
+			rid := config.ParseResourceID(rawID)
+			if rid.Name == "" {
+				return nil, fmt.Errorf("%s - invalid AppGW WAF policy id: %s", funcName, rawID)
+			}
+
+			rids = append(rids, rid)
+		}
+	} else {
+		all, err := GetAllAppGWPolicies(s, i)
+		if err != nil {
+			return nil, fmt.Errorf("%s - %w", funcName, err)
+		}
+
+		for _, p := range all {
+			rids = append(rids, config.ParseResourceID(*p.ID))
+		}
+	}
+
+	var out []WrappedAppGWPolicy
+
+	for _, rid := range rids {
+		logrus.Debugf("retrieving raw AppGW WAF policy: %s %s %s", rid.SubscriptionID, rid.ResourceGroup, rid.Name)
+
+		p, err := GetRawAppGWPolicy(s, rid.SubscriptionID, rid.ResourceGroup, rid.Name)
+		if err != nil {
+			return nil, fmt.Errorf("%s - %w", funcName, err)
+		}
+
+		out = append(out, WrappedAppGWPolicy{
+			Date:           time.Now().UTC(),
+			SubscriptionID: rid.SubscriptionID,
+			ResourceGroup:  rid.ResourceGroup,
+			Name:           rid.Name,
+			Policy:         *p,
+			PolicyID:       rid.Raw,
+			AppVersion:     i.AppVersion,
+			WAFType:        WAFTypeAppGW,
+		})
+	}
+
+	return out, nil
+}
+
+// PushAppGWPolicyInput defines the input for PushAppGWPolicy.
+type PushAppGWPolicyInput struct {
+	Name          string
+	Subscription  string
+	ResourceGroup string
+	Policy        armnetwork.WebApplicationFirewallPolicy
+	Debug         bool
+}
+
+// PushAppGWPolicy creates or updates an Application Gateway WAF policy.
+// The AppGW SDK exposes CreateOrUpdate as a synchronous call.
+func PushAppGWPolicy(s *session.Session, i *PushAppGWPolicyInput) error {
+	funcName := GetFunctionName()
+
+	logrus.Debugf("pushing AppGW WAF policy %s...", i.Name)
+
+	if err := s.GetAppGWPoliciesClient(i.Subscription); err != nil {
+		return fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	ctx := context.Background()
+
+	_, err := s.AppGWPoliciesClients[i.Subscription].CreateOrUpdate(ctx, i.ResourceGroup, i.Name, i.Policy, nil)
+	if err != nil {
+		return fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	logrus.Infof("AppGW WAF policy %s updated", i.Name)
+
+	return nil
+}
+
+// LoadWrappedAppGWPolicyFromFile loads a WrappedAppGWPolicy backup file.
+func LoadWrappedAppGWPolicyFromFile(data []byte) (WrappedAppGWPolicy, error) {
+	funcName := GetFunctionName()
+
+	var wp WrappedAppGWPolicy
+	if err := json.Unmarshal(data, &wp); err != nil {
+		return WrappedAppGWPolicy{}, fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	if wp.Policy.Properties == nil {
+		return WrappedAppGWPolicy{}, fmt.Errorf("%s - wrapped AppGW policy is invalid", funcName)
+	}
+
+	return wp, nil
+}
+
+// GenerateAppGWPolicyPatch reuses the JSON-path-based diff stats from the FD
+// patch generator so restore confirmation prompts work consistently.
+func GenerateAppGWPolicyPatch(original interface{}, newPolicy armnetwork.WebApplicationFirewallPolicy) (GeneratePolicyPatchOutput, error) {
+	funcName := GetFunctionName()
+
+	var output GeneratePolicyPatchOutput
+
+	originalBytes, err := marshalAppGWOriginal(original)
+	if err != nil {
+		return output, fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	newJSON, err := json.MarshalIndent(newPolicy, "", "    ")
+	if err != nil {
+		return output, fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	patch, err := jsondiff.CompareJSON(originalBytes, newJSON)
+	if err != nil {
+		return output, fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	return calculatePatchStats(patch), nil
+}
+
+func marshalAppGWOriginal(original interface{}) ([]byte, error) {
+	switch v := original.(type) {
+	case []byte:
+		return v, nil
+	case armnetwork.WebApplicationFirewallPolicy:
+		return json.MarshalIndent(v, "", "    ")
+	case WrappedAppGWPolicy:
+		return json.MarshalIndent(v.Policy, "", "    ")
+	default:
+		return nil, fmt.Errorf("unexpected original type for AppGW policy: %T", original)
+	}
+}

--- a/policy/appgw_restore.go
+++ b/policy/appgw_restore.go
@@ -1,0 +1,333 @@
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
+	"github.com/jonhadfield/azwaf/config"
+	"github.com/jonhadfield/azwaf/session"
+	"github.com/sirupsen/logrus"
+)
+
+// ProcessAppGWPolicyChangesInput is the AppGW analogue of ProcessPolicyChangesInput.
+type ProcessAppGWPolicyChangesInput struct {
+	Session          *session.Session
+	PolicyName       string
+	SubscriptionID   string
+	ResourceGroup    string
+	PolicyPostChange armnetwork.WebApplicationFirewallPolicy
+	ShowDiff         bool
+	DryRun           bool
+	Backup           bool
+	Debug            bool
+}
+
+// ProcessAppGWPolicyChanges fetches the existing AppGW policy, optionally
+// shows a diff and creates a pre-change backup, then pushes the new policy.
+func ProcessAppGWPolicyChanges(input *ProcessAppGWPolicyChangesInput) error {
+	funcName := GetFunctionName()
+
+	preChange, err := GetRawAppGWPolicy(input.Session, input.SubscriptionID, input.ResourceGroup, input.PolicyName)
+	if err != nil {
+		// the existing policy may not exist yet (first-time restore). only treat
+		// "not found" as non-fatal; everything else is a real error.
+		if !isAppGWNotFound(err) {
+			return fmt.Errorf("%s - %w", funcName, err)
+		}
+
+		preChange = nil
+	}
+
+	if input.ShowDiff && preChange != nil {
+		if err := DisplayPolicyDiff(preChange, input.PolicyPostChange); err != nil {
+			return fmt.Errorf("%s - %w", funcName, err)
+		}
+	}
+
+	if input.DryRun {
+		logrus.Infof("%s | changes were not applied as dry-run was requested", funcName)
+
+		return nil
+	}
+
+	if input.Backup && preChange != nil {
+		policyID := ""
+		if preChange.ID != nil {
+			policyID = *preChange.ID
+		}
+
+		err := BackupAppGWPolicy(&WrappedAppGWPolicy{
+			SubscriptionID: input.SubscriptionID,
+			ResourceGroup:  input.ResourceGroup,
+			Name:           input.PolicyName,
+			Policy:         *preChange,
+			PolicyID:       policyID,
+			AppVersion:     input.Session.AppVersion,
+			WAFType:        WAFTypeAppGW,
+		}, nil, "", true, false, input.Session.BackupsDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	return PushAppGWPolicy(input.Session, &PushAppGWPolicyInput{
+		Name:          input.PolicyName,
+		Subscription:  input.SubscriptionID,
+		ResourceGroup: input.ResourceGroup,
+		Policy:        input.PolicyPostChange,
+		Debug:         input.Debug,
+	})
+}
+
+func isAppGWNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// prefer the typed check: a 403/409 etc. containing "NotFound" in its
+	// message must not be mistaken for a missing policy
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		return respErr.StatusCode == http.StatusNotFound
+	}
+
+	msg := err.Error()
+
+	return strings.Contains(msg, "ResourceNotFound") ||
+		strings.Contains(msg, "NotFound") ||
+		strings.Contains(msg, "404")
+}
+
+type appgwRestorePair struct {
+	original, updated *WrappedAppGWPolicy
+}
+
+func loadExistingAppGWPolicy(s *session.Session, targetPolicy string) (*WrappedAppGWPolicy, error) {
+	if targetPolicy == "" {
+		return nil, nil
+	}
+
+	rid := config.ParseResourceID(targetPolicy)
+	if rid.Name == "" {
+		return nil, fmt.Errorf("invalid AppGW WAF policy id: %s", targetPolicy)
+	}
+
+	p, err := GetRawAppGWPolicy(s, rid.SubscriptionID, rid.ResourceGroup, rid.Name)
+	if err != nil {
+		if isAppGWNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return &WrappedAppGWPolicy{
+		Date:           time.Now().UTC(),
+		SubscriptionID: rid.SubscriptionID,
+		ResourceGroup:  rid.ResourceGroup,
+		Name:           rid.Name,
+		Policy:         *p,
+		PolicyID:       rid.Raw,
+		WAFType:        WAFTypeAppGW,
+	}, nil
+}
+
+// CompileAppGWPoliciesToRestore mirrors CompilePoliciesToRestore for AppGW.
+func CompileAppGWPoliciesToRestore(s *session.Session, backups []WrappedAppGWPolicy, i *RestorePoliciesInput) ([]appgwRestorePair, error) {
+	funcName := GetFunctionName()
+
+	var results []appgwRestorePair
+
+	for _, backup := range backups {
+		matchID := backup.PolicyID
+		if i.TargetPolicy != "" {
+			matchID = i.TargetPolicy
+		}
+
+		var existing *WrappedAppGWPolicy
+
+		if matchID != "" {
+			var err error
+			existing, err = loadExistingAppGWPolicy(s, matchID)
+			if err != nil {
+				return nil, fmt.Errorf("%s - %w", funcName, err)
+			}
+		}
+
+		var patch GeneratePolicyPatchOutput
+		if existing != nil {
+			var err error
+			patch, err = GenerateAppGWPolicyPatch(existing.Policy, backup.Policy)
+			if err != nil {
+				return nil, fmt.Errorf("%s - %w", funcName, err)
+			}
+		}
+
+		matched := WrappedAppGWPolicy{}
+		if existing != nil {
+			matched = *existing
+		}
+
+		ok, err := shouldRestore(existing != nil, dummyWrappedFromAppGW(matched), backup.toFDLikeBackup(), i, patch)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+
+		restored := BuildRestoredAppGWPolicy(existing, &backup, i)
+		var originalCopy *WrappedAppGWPolicy
+		if existing != nil {
+			c := *existing
+			originalCopy = &c
+		}
+
+		results = append(results, appgwRestorePair{original: originalCopy, updated: &restored})
+	}
+
+	return results, nil
+}
+
+// dummyWrappedFromAppGW provides a minimal FD-shaped WrappedPolicy so we can
+// reuse the existing shouldRestore confirmation logic. Only PolicyID and Date
+// are read from it, which both types share.
+func dummyWrappedFromAppGW(w WrappedAppGWPolicy) WrappedPolicy {
+	return WrappedPolicy{
+		Date:           w.Date,
+		SubscriptionID: w.SubscriptionID,
+		ResourceGroup:  w.ResourceGroup,
+		Name:           w.Name,
+		PolicyID:       w.PolicyID,
+	}
+}
+
+// toFDLikeBackup is the same conversion for the backup side. shouldRestore
+// reads only PolicyID and Date from the second argument.
+func (w WrappedAppGWPolicy) toFDLikeBackup() WrappedPolicy {
+	return dummyWrappedFromAppGW(w)
+}
+
+// BuildRestoredAppGWPolicy is the AppGW analogue of BuildRestoredPolicy. It
+// honours CustomRulesOnly / ManagedRulesOnly partial restore semantics.
+func BuildRestoredAppGWPolicy(existing, backup *WrappedAppGWPolicy, i *RestorePoliciesInput) WrappedAppGWPolicy {
+	// no existing policy: brand new restore
+	if existing == nil || existing.PolicyID == "" {
+		return WrappedAppGWPolicy{
+			SubscriptionID: i.SubscriptionID,
+			ResourceGroup:  i.ResourceGroup,
+			Name:           backup.Name,
+			Policy:         backup.Policy,
+			WAFType:        WAFTypeAppGW,
+		}
+	}
+
+	// copy the wrapper and clone Properties so the rule-set assignments below
+	// don't write through the pointer shared with the caller's value. Deeper
+	// fields remain shared, but they are only ever replaced wholesale here,
+	// never mutated in place.
+	updated := *existing
+	if existing.Policy.Properties != nil {
+		propsCopy := *existing.Policy.Properties
+		updated.Policy.Properties = &propsCopy
+	} else {
+		updated.Policy.Properties = &armnetwork.WebApplicationFirewallPolicyPropertiesFormat{}
+	}
+
+	switch {
+	case i.CustomRulesOnly:
+		if backup.Policy.Properties != nil {
+			updated.Policy.Properties.CustomRules = backup.Policy.Properties.CustomRules
+		} else {
+			updated.Policy.Properties.CustomRules = nil
+		}
+	case i.ManagedRulesOnly:
+		if backup.Policy.Properties != nil {
+			updated.Policy.Properties.ManagedRules = backup.Policy.Properties.ManagedRules
+		} else {
+			updated.Policy.Properties.ManagedRules = nil
+		}
+	default:
+		// full replace of both rule sets
+		if backup.Policy.Properties != nil {
+			updated.Policy.Properties.CustomRules = backup.Policy.Properties.CustomRules
+			updated.Policy.Properties.ManagedRules = backup.Policy.Properties.ManagedRules
+		}
+	}
+
+	rid := config.ParseResourceID(updated.PolicyID)
+
+	return WrappedAppGWPolicy{
+		SubscriptionID: rid.SubscriptionID,
+		ResourceGroup:  rid.ResourceGroup,
+		Name:           rid.Name,
+		Policy:         updated.Policy,
+		PolicyID:       updated.PolicyID,
+		WAFType:        WAFTypeAppGW,
+	}
+}
+
+// restoreAppGWBackups walks compiled AppGW restore pairs and applies each.
+func restoreAppGWBackups(s *session.Session, i *RestorePoliciesInput, backups []WrappedAppGWPolicy) error {
+	funcName := GetFunctionName()
+
+	if i.TargetPolicy != "" {
+		// ensure only one backup file when targeting a single policy. The
+		// caller (RestorePolicies) has already enforced this across both WAF
+		// types, so this is a defensive check.
+		if len(backups) > 1 {
+			return fmt.Errorf("%s - restoring more than one backup to a single policy doesn't make sense", funcName)
+		}
+
+		if IsRIDHash(i.TargetPolicy) {
+			return fmt.Errorf("%s - AppGW WAF restore targets must be a full resource id, not a hash", funcName)
+		}
+	}
+
+	pairs, err := CompileAppGWPoliciesToRestore(s, backups, i)
+	if err != nil {
+		return err
+	}
+
+	if len(pairs) == 0 {
+		return nil
+	}
+
+	// only retarget when the user explicitly supplied --target: without one,
+	// each compiled pair already carries its own backup's identity, and
+	// overriding pairs[0] could retarget the wrong backup if an earlier one
+	// was skipped at the confirmation prompt
+	if i.TargetPolicy != "" {
+		rids, err := ConvertToResourceIDs([]string{i.TargetPolicy}, i.SubscriptionID)
+		if err != nil {
+			return err
+		}
+
+		pairs[0].updated.SubscriptionID = rids[0].SubscriptionID
+		pairs[0].updated.ResourceGroup = rids[0].ResourceGroup
+		pairs[0].updated.Name = rids[0].Name
+	}
+
+	for x := range pairs {
+		if err := ProcessAppGWPolicyChanges(&ProcessAppGWPolicyChangesInput{
+			Session:          s,
+			PolicyName:       pairs[x].updated.Name,
+			SubscriptionID:   pairs[x].updated.SubscriptionID,
+			ResourceGroup:    pairs[x].updated.ResourceGroup,
+			ShowDiff:         i.ShowDiff,
+			PolicyPostChange: pairs[x].updated.Policy,
+			DryRun:           i.DryRun,
+			Backup:           i.AutoBackup,
+			Debug:            i.Debug,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/policy/appgw_test.go
+++ b/policy/appgw_test.go
@@ -1,0 +1,118 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
+	"github.com/jonhadfield/azwaf/config"
+	"github.com/stretchr/testify/require"
+)
+
+func newAppGWPolicyForTest() armnetwork.WebApplicationFirewallPolicy {
+	owasp := "OWASP"
+	v32 := "3.2"
+	return armnetwork.WebApplicationFirewallPolicy{
+		Properties: &armnetwork.WebApplicationFirewallPolicyPropertiesFormat{
+			ManagedRules: &armnetwork.ManagedRulesDefinition{
+				ManagedRuleSets: []*armnetwork.ManagedRuleSet{
+					{RuleSetType: &owasp, RuleSetVersion: &v32},
+				},
+			},
+		},
+	}
+}
+
+func TestWAFTypeFromResourceID(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{
+			name: "frontdoor lowercase",
+			id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/frontdoorWebApplicationFirewallPolicies/p1",
+			want: WAFTypeFrontDoor,
+		},
+		{
+			name: "appgw mixed case",
+			id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/p2",
+			want: WAFTypeAppGW,
+		},
+		{
+			name: "appgw lower case",
+			id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/applicationgatewaywebapplicationfirewallpolicies/p3",
+			want: WAFTypeAppGW,
+		},
+		{
+			name: "non-resource-id falls back to FrontDoor",
+			id:   "abc123",
+			want: WAFTypeFrontDoor,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, WAFTypeFromResourceID(tc.id))
+		})
+	}
+}
+
+func TestParseResourceIDPopulatesResourceType(t *testing.T) {
+	rid := config.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/p")
+	require.Equal(t, ResourceTypeAppGWWAF, rid.ResourceType)
+
+	rid = config.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/frontdoorWebApplicationFirewallPolicies/p")
+	require.Equal(t, ResourceTypeFrontDoorWAF, rid.ResourceType)
+}
+
+func TestPartitionRIDsByWAFType(t *testing.T) {
+	fdID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/frontdoorWebApplicationFirewallPolicies/fd"
+	appgwID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/agw"
+
+	fd, agw := partitionRIDsByWAFType([]string{fdID, appgwID, "abc123"})
+
+	require.Equal(t, []string{fdID, "abc123"}, fd)
+	require.Equal(t, []string{appgwID}, agw)
+}
+
+func TestLoadAllBackupsFromPathsDispatchesByType(t *testing.T) {
+	loaded, err := LoadAllBackupsFromPaths([]string{
+		"../testfiles/wrapped-policy-one.json",
+		"../testfiles/wrapped-appgw-policy-one.json",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, loaded.FrontDoor, 1)
+	require.Len(t, loaded.AppGW, 1)
+
+	require.Equal(t, "/subscriptions/0a914e76-4921-4c19-b460-a2d36003525a/resourceGroups/flying/providers/Microsoft.Network/frontdoorWebApplicationFirewallPolicies/mypolicyone", loaded.FrontDoor[0].PolicyID)
+
+	agw := loaded.AppGW[0]
+	require.Equal(t, "appgw-policy-one", agw.Name)
+	require.Equal(t, WAFTypeAppGW, agw.WAFType)
+	require.NotNil(t, agw.Policy.Properties)
+	require.NotNil(t, agw.Policy.Properties.ManagedRules)
+	require.Len(t, agw.Policy.Properties.ManagedRules.ManagedRuleSets, 1)
+}
+
+func TestBuildRestoredAppGWPolicyNewPolicy(t *testing.T) {
+	backup := &WrappedAppGWPolicy{
+		Name:    "agw1",
+		Policy:  newAppGWPolicyForTest(),
+		WAFType: WAFTypeAppGW,
+	}
+
+	got := BuildRestoredAppGWPolicy(nil, backup, &RestorePoliciesInput{
+		ResourceGroup: "rg",
+		BaseCLIInput:  BaseCLIInput{SubscriptionID: "00000000-0000-0000-0000-000000000000"},
+	})
+
+	require.Equal(t, "rg", got.ResourceGroup)
+	require.Equal(t, "agw1", got.Name)
+	require.Equal(t, WAFTypeAppGW, got.WAFType)
+}
+
+func TestLoadWrappedAppGWPolicyFromFileRejectsInvalid(t *testing.T) {
+	_, err := LoadWrappedAppGWPolicyFromFile([]byte(`{"WAFType":"ApplicationGateway"}`))
+	require.Error(t, err)
+}

--- a/policy/backup.go
+++ b/policy/backup.go
@@ -48,7 +48,11 @@ func (in *BackupPoliciesInput) Validate() error {
 	return nil
 }
 
-// BackupPolicies retrieves policies within a subscription and writes them, with meta-data, to individual json files
+// BackupPolicies retrieves policies within a subscription and writes them, with meta-data, to individual json files.
+// Both Azure Front Door and Azure Application Gateway WAF policies are
+// supported; the resource type embedded in each resource id determines which
+// API the policy is fetched from. When no resource ids are supplied, every WAF
+// policy of either type within the subscription is backed up.
 func BackupPolicies(in *BackupPoliciesInput) error {
 	funcName := GetFunctionName()
 
@@ -77,17 +81,63 @@ func BackupPolicies(in *BackupPoliciesInput) error {
 			funcName)
 	}
 
-	o, err := GetWrappedPoliciesFromRawIDs(s, GetWrappedPoliciesInput{
-		SubscriptionID:    in.SubscriptionID,
-		AppVersion:        in.AppVersion,
-		FilterResourceIDs: in.RIDs,
-		Config:            in.ConfigPath,
-	})
-	if err != nil {
-		return err
+	fdRIDs, appgwRIDs := partitionRIDsByWAFType(in.RIDs)
+
+	var (
+		fdPolicies    []WrappedPolicy
+		appgwPolicies []WrappedAppGWPolicy
+		err           error
+	)
+
+	switch {
+	case len(in.RIDs) == 0:
+		// no filter: fetch every FD and every AppGW WAF policy in the subscription
+		var fd GetWrappedPoliciesOutput
+		fd, err = GetWrappedPoliciesFromRawIDs(s, GetWrappedPoliciesInput{
+			SubscriptionID: in.SubscriptionID,
+			AppVersion:     in.AppVersion,
+			Config:         in.ConfigPath,
+		})
+		if err != nil {
+			return err
+		}
+		fdPolicies = fd.Policies
+
+		appgwPolicies, err = GetWrappedAppGWPoliciesFromRawIDs(s, GetWrappedPoliciesInput{
+			SubscriptionID: in.SubscriptionID,
+			AppVersion:     in.AppVersion,
+		})
+		if err != nil {
+			return err
+		}
+	default:
+		if len(fdRIDs) > 0 {
+			var fd GetWrappedPoliciesOutput
+			fd, err = GetWrappedPoliciesFromRawIDs(s, GetWrappedPoliciesInput{
+				SubscriptionID:    in.SubscriptionID,
+				AppVersion:        in.AppVersion,
+				FilterResourceIDs: fdRIDs,
+				Config:            in.ConfigPath,
+			})
+			if err != nil {
+				return err
+			}
+			fdPolicies = fd.Policies
+		}
+
+		if len(appgwRIDs) > 0 {
+			appgwPolicies, err = GetWrappedAppGWPoliciesFromRawIDs(s, GetWrappedPoliciesInput{
+				SubscriptionID:    in.SubscriptionID,
+				AppVersion:        in.AppVersion,
+				FilterResourceIDs: appgwRIDs,
+			})
+			if err != nil {
+				return err
+			}
+		}
 	}
 
-	logrus.Debugf("%s | retrieved %d policies", funcName, len(o.Policies))
+	logrus.Debugf("%s | retrieved %d FrontDoor and %d AppGW policies", funcName, len(fdPolicies), len(appgwPolicies))
 
 	var blobClient *azblob.Client
 	var containerName string
@@ -133,7 +183,28 @@ func BackupPolicies(in *BackupPoliciesInput) error {
 		containerName = parts.ContainerName
 	}
 
-	return backupPolicies(o.Policies, blobClient, containerName, in.FailFast, in.Quiet, in.Path)
+	if err = backupPolicies(fdPolicies, blobClient, containerName, in.FailFast, in.Quiet, in.Path); err != nil {
+		return err
+	}
+
+	return backupAppGWPolicies(appgwPolicies, blobClient, containerName, in.FailFast, in.Quiet, in.Path)
+}
+
+// partitionRIDsByWAFType splits a mixed list of WAF resource ids into a Front
+// Door slice and an Application Gateway slice. Anything that does not parse as
+// AppGW falls into the FrontDoor slice — including resource id hashes which
+// are still resolved through the FrontDoor lookup path.
+func partitionRIDsByWAFType(rids []string) (fd, appgw []string) {
+	for _, r := range rids {
+		if WAFTypeFromResourceID(r) == WAFTypeAppGW {
+			appgw = append(appgw, r)
+			continue
+		}
+
+		fd = append(fd, r)
+	}
+
+	return fd, appgw
 }
 
 // BackupPolicy takes a WrappedPolicy as input and creates a json file that can later be restored
@@ -159,7 +230,7 @@ func BackupPolicy(p *WrappedPolicy, blobClient *azblob.Client, containerName str
 
 		width, _, terr := terminal.GetSize(fd)
 		if terr != nil {
-			return fmt.Errorf(terr.Error(), funcName)
+			return fmt.Errorf("%s - %w", funcName, terr)
 		}
 
 		if len(statusOutput) == width {
@@ -175,7 +246,11 @@ func BackupPolicy(p *WrappedPolicy, blobClient *azblob.Client, containerName str
 			return oerr
 		}
 
-		logrus.Error(err)
+		logrus.Errorf("failed to marshal policy %s: %s", p.Name, oerr)
+
+		// nothing valid to write for this policy; skip it rather than
+		// uploading empty content
+		return nil
 	}
 
 	fName := fmt.Sprintf("%s+%s+%s+%s.json", p.SubscriptionID, p.ResourceGroup, p.Name, dateString)
@@ -201,7 +276,7 @@ func BackupPolicy(p *WrappedPolicy, blobClient *azblob.Client, containerName str
 	if path != "" {
 		err = writeBackupToFile(pj, cwd, fName, quiet, path)
 		if err != nil {
-			return fmt.Errorf(err.Error(), funcName)
+			return fmt.Errorf("%s - %w", funcName, err)
 		}
 	}
 
@@ -247,14 +322,115 @@ func writeBackupToFile(pj []byte, cwd, fName string, quiet bool, path string) (e
 // backupPolicies accepts a list of WrappedPolicys and calls BackupPolicy with each
 func backupPolicies(policies []WrappedPolicy, blobClient *azblob.Client, containerName string, failFast, quiet bool, path string) (err error) {
 	for x := range policies {
-		err = BackupPolicy(&policies[x], blobClient, containerName, failFast, quiet, path)
+		// tag every newly produced backup with its WAF type so restore can
+		// dispatch correctly. Older files (without WAFType) default to FrontDoor.
+		if policies[x].WAFType == "" {
+			policies[x].WAFType = WAFTypeFrontDoor
+		}
 
-		if failFast {
-			return
+		// return only on error: previously this returned unconditionally under
+		// fail-fast, silently skipping every policy after the first
+		if err = BackupPolicy(&policies[x], blobClient, containerName, failFast, quiet, path); err != nil {
+			if failFast {
+				return err
+			}
+
+			logrus.Error(err)
 		}
 	}
 
-	return
+	return nil
+}
+
+// BackupAppGWPolicy is the AppGW analogue of BackupPolicy. It writes the
+// supplied WrappedAppGWPolicy as JSON to disk and/or Azure Blob Storage.
+func BackupAppGWPolicy(p *WrappedAppGWPolicy, blobClient *azblob.Client, containerName string, failFast, quiet bool, path string) error {
+	funcName := GetFunctionName()
+	now := time.Now().UTC()
+	dateString := now.UTC().Format("20060102150405")
+	p.Date = now
+
+	if p.WAFType == "" {
+		p.WAFType = WAFTypeAppGW
+	}
+
+	var cwd string
+
+	if !quiet {
+		var oerr error
+
+		cwd, oerr = os.Getwd()
+		if oerr != nil {
+			return oerr
+		}
+
+		msg := fmt.Sprintf("backing up AppGW Policy: %s", p.Name)
+		statusOutput := PadToWidth(msg, " ", 0, true)
+		fd := int(os.Stdout.Fd())
+
+		width, _, terr := terminal.GetSize(fd)
+		if terr != nil {
+			return fmt.Errorf("%s - %w", funcName, terr)
+		}
+
+		if len(statusOutput) == width {
+			fmt.Print(statusOutput[0:width-3] + "   \r")
+		} else {
+			fmt.Print(statusOutput)
+		}
+	}
+
+	pj, oerr := json.MarshalIndent(p, "", "    ")
+	if oerr != nil {
+		if failFast {
+			return oerr
+		}
+
+		logrus.Errorf("failed to marshal AppGW policy %s: %s", p.Name, oerr)
+
+		// nothing valid to write for this policy; skip it rather than
+		// uploading empty content
+		return nil
+	}
+
+	fName := fmt.Sprintf("%s+%s+%s+%s.json", p.SubscriptionID, p.ResourceGroup, p.Name, dateString)
+
+	if blobClient != nil {
+		ctx := context.Background()
+
+		if !quiet {
+			logrus.Infof("uploading file with blob name: %s\n", fName)
+		}
+
+		if _, oerr = blobClient.UploadBuffer(ctx, containerName, fName, pj, &azblob.UploadBufferOptions{
+			BlockSize:   blockBlobUploadBlockSize,
+			Concurrency: blockBlobParallelism,
+		}); oerr != nil {
+			return oerr
+		}
+	}
+
+	if path != "" {
+		if err := writeBackupToFile(pj, cwd, fName, quiet, path); err != nil {
+			return fmt.Errorf("%s - %w", funcName, err)
+		}
+	}
+
+	return nil
+}
+
+func backupAppGWPolicies(policies []WrappedAppGWPolicy, blobClient *azblob.Client, containerName string, failFast, quiet bool, path string) error {
+	for x := range policies {
+		if err := BackupAppGWPolicy(&policies[x], blobClient, containerName, failFast, quiet, path); err != nil {
+			if failFast {
+				return err
+			}
+
+			logrus.Error(err)
+		}
+	}
+
+	return nil
 }
 
 func PadToWidth(input, char string, inputLengthOverride int, trimToWidth bool) string {

--- a/policy/data.go
+++ b/policy/data.go
@@ -274,3 +274,119 @@ func LoadBackupsFromPath(rootPath string) ([]WrappedPolicy, error) {
 
 	return wps, nil
 }
+
+// LoadedBackups separates loaded backup files by WAF type.
+type LoadedBackups struct {
+	FrontDoor []WrappedPolicy
+	AppGW     []WrappedAppGWPolicy
+}
+
+// wafTypePeek is used to identify the WAF type of a backup file before fully
+// unmarshaling it into the correct concrete type.
+type wafTypePeek struct {
+	WAFType string `json:"WAFType"`
+}
+
+// LoadAllBackupsFromPaths walks each path (file or directory) and loads every
+// JSON backup it finds, dispatching each file to either the FrontDoor or AppGW
+// type based on the WAFType field embedded in the backup. Backups produced by
+// older versions of azwaf have no WAFType and are treated as FrontDoor.
+func LoadAllBackupsFromPaths(paths []string) (LoadedBackups, error) {
+	funcName := GetFunctionName()
+
+	if len(paths) == 0 {
+		return LoadedBackups{}, fmt.Errorf("%s - no paths provided", funcName)
+	}
+
+	var out LoadedBackups
+
+	for _, p := range paths {
+		got, err := loadAllBackupsFromPath(p)
+		if err != nil {
+			return LoadedBackups{}, fmt.Errorf("%s - %w", funcName, err)
+		}
+
+		out.FrontDoor = append(out.FrontDoor, got.FrontDoor...)
+		out.AppGW = append(out.AppGW, got.AppGW...)
+	}
+
+	logrus.Debugf("loaded %d FrontDoor and %d AppGW policy backups", len(out.FrontDoor), len(out.AppGW))
+
+	return out, nil
+}
+
+func loadAllBackupsFromPath(rootPath string) (LoadedBackups, error) {
+	funcName := GetFunctionName()
+
+	info, err := os.Stat(rootPath)
+	if err != nil {
+		return LoadedBackups{}, fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	if !info.IsDir() {
+		if !strings.EqualFold(filepath.Ext(info.Name()), ".json") {
+			return LoadedBackups{}, fmt.Errorf("%s - %s is not a json file", funcName, rootPath)
+		}
+
+		return loadBackupFile(rootPath)
+	}
+
+	files, err := os.ReadDir(rootPath)
+	if err != nil {
+		return LoadedBackups{}, fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	var out LoadedBackups
+
+	for _, f := range files {
+		if f.IsDir() || !strings.EqualFold(filepath.Ext(f.Name()), ".json") {
+			continue
+		}
+
+		got, err := loadBackupFile(filepath.Join(rootPath, f.Name()))
+		if err != nil {
+			return LoadedBackups{}, fmt.Errorf("%s - %w", funcName, err)
+		}
+
+		out.FrontDoor = append(out.FrontDoor, got.FrontDoor...)
+		out.AppGW = append(out.AppGW, got.AppGW...)
+	}
+
+	return out, nil
+}
+
+func loadBackupFile(path string) (LoadedBackups, error) {
+	funcName := GetFunctionName()
+	logrus.Debugf("%s | loading file %s", funcName, path)
+
+	// #nosec
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return LoadedBackups{}, fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	var peek wafTypePeek
+	if err := json.Unmarshal(data, &peek); err != nil {
+		return LoadedBackups{}, fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	if peek.WAFType == WAFTypeAppGW {
+		wp, err := LoadWrappedAppGWPolicyFromFile(data)
+		if err != nil {
+			return LoadedBackups{}, fmt.Errorf("%s - %w", funcName, err)
+		}
+
+		return LoadedBackups{AppGW: []WrappedAppGWPolicy{wp}}, nil
+	}
+
+	var wp WrappedPolicy
+	if err := json.Unmarshal(data, &wp); err != nil {
+		return LoadedBackups{}, fmt.Errorf("%s - %w", funcName, err)
+	}
+
+	if wp.Policy.Properties == nil {
+		return LoadedBackups{}, fmt.Errorf("%s - wrapped policy is invalid", funcName)
+	}
+
+	return LoadedBackups{FrontDoor: []WrappedPolicy{wp}}, nil
+}

--- a/policy/id.go
+++ b/policy/id.go
@@ -10,9 +10,9 @@ import (
 const ridHashLength = 8
 
 func IsRIDHash(s string) bool {
-    if len(s) != ridHashLength {
-        return false
-    }
+	if len(s) != ridHashLength {
+		return false
+	}
 
 	hashExp := regexp.MustCompile(`[a-f\d]{8}`)
 

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -99,16 +99,15 @@ func GetWAFResourceIDHashMap(s *session.Session) (hashMap WAFResourceIDHashMap, 
 
 	cacheEntry, err := cache.Read(s, WAFResourceIDHashMapName)
 	if err != nil {
-		return hashMap, fmt.Errorf(err.Error(), funcName)
+		return hashMap, fmt.Errorf("%s - %w", funcName, err)
 	}
 
 	if cacheEntry == "" {
 		return
 	}
 
-	jerr := json.Unmarshal([]byte(cacheEntry), &hashMap)
-	if jerr != nil {
-		err = fmt.Errorf(err.Error(), funcName)
+	if jerr := json.Unmarshal([]byte(cacheEntry), &hashMap); jerr != nil {
+		err = fmt.Errorf("%s - %w", funcName, jerr)
 	}
 
 	return
@@ -313,7 +312,7 @@ func GetRawPolicy(s *session.Session, subscription, resourceGroup, name string) 
 	err := s.GetFrontDoorPoliciesClient(subscription)
 	clientDuration := time.Since(clientStartTime)
 	logrus.Infof("%s | Client initialization took: %v", funcName, clientDuration)
-	
+
 	if err != nil {
 		return nil, fmt.Errorf("%s - %w", funcName, err)
 	}
@@ -337,14 +336,14 @@ func GetRawPolicy(s *session.Session, subscription, resourceGroup, name string) 
 	// Time the actual API call
 	apiStartTime := time.Now()
 	logrus.Infof("%s | Making API call to Azure (timeout: %v)", funcName, policyGetTimeout)
-	
+
 	pcg, merr := s.FrontDoorPoliciesClients[subscription].Get(ctx, resourceGroup, name, &options)
-	
+
 	apiDuration := time.Since(apiStartTime)
 	totalDuration := time.Since(startTime)
-	
+
 	logrus.Infof("%s | API call completed in: %v (total time: %v)", funcName, apiDuration, totalDuration)
-	
+
 	if merr != nil {
 		logrus.Errorf("%s | API call failed after %v: %s", funcName, apiDuration, merr.Error())
 		return nil, fmt.Errorf("%s - %s", funcName, merr.Error())
@@ -553,6 +552,7 @@ type WrappedPolicy struct {
 	Policy         armfrontdoor.WebApplicationFirewallPolicy
 	PolicyID       string
 	AppVersion     string
+	WAFType        string `json:",omitempty"`
 }
 
 type WrappedManagedRuleSet struct {
@@ -596,37 +596,50 @@ func marshalPolicy(original interface{}) ([]byte, error) {
 	}
 }
 
+// patchPathInSection reports whether a JSON patch path is the section itself
+// or anything beneath it. The exact match matters: adding or removing an
+// entire section (e.g. a policy gaining customRules where it had none)
+// produces a single op at the section path with no trailing slash.
+func patchPathInSection(path, section string) bool {
+	return path == section || strings.HasPrefix(path, section+"/")
+}
+
 func calculatePatchStats(patch jsondiff.Patch) GeneratePolicyPatchOutput {
 	var output GeneratePolicyPatchOutput
 
 	output.TotalDifferences = len(patch)
+
+	const (
+		customRulesPath  = "/properties/customRules"
+		managedRulesPath = "/properties/managedRules"
+	)
 
 	for _, op := range patch {
 		logrus.Trace(op.String())
 
 		switch op.Type {
 		case "add":
-			if strings.HasPrefix(string(op.Path), "/properties/customRules/") {
+			if patchPathInSection(string(op.Path), customRulesPath) {
 				output.CustomRuleAdditions++
 			}
 
-			if strings.HasPrefix(string(op.Path), "/properties/managedRules/") {
+			if patchPathInSection(string(op.Path), managedRulesPath) {
 				output.ManagedRuleAdditions++
 			}
 		case "remove":
-			if strings.HasPrefix(string(op.Path), "/properties/customRules/") {
+			if patchPathInSection(string(op.Path), customRulesPath) {
 				output.CustomRuleRemovals++
 			}
 
-			if strings.HasPrefix(string(op.Path), "/properties/managedRules/") {
+			if patchPathInSection(string(op.Path), managedRulesPath) {
 				output.ManagedRuleRemovals++
 			}
 		case "replace":
-			if strings.HasPrefix(string(op.Path), "/properties/customRules/") {
+			if patchPathInSection(string(op.Path), customRulesPath) {
 				output.CustomRuleReplacements++
 			}
 
-			if strings.HasPrefix(string(op.Path), "/properties/managedRules/") {
+			if patchPathInSection(string(op.Path), managedRulesPath) {
 				output.ManagedRuleReplacements++
 			}
 		}

--- a/policy/restore.go
+++ b/policy/restore.go
@@ -98,98 +98,141 @@ func (i *RestorePoliciesInput) Validate() error {
 	// check target policy if specified
 	if i.TargetPolicy != "" {
 		if ValidateResourceID(i.TargetPolicy, false) != nil {
-			return fmt.Errorf(fmt.Sprintf("target policy '%s' is invalid", i.TargetPolicy), funcName)
+			return fmt.Errorf("%s - target policy '%s' is invalid", funcName, i.TargetPolicy)
 		}
 	}
 
 	return nil
 }
 
-// RestorePolicies loads existing backup(s) from files and then adds/overwrites based on user's choices
-func RestorePolicies(i *RestorePoliciesInput) (err error) {
+// RestorePolicies loads existing backup(s) from files and then adds/overwrites
+// based on the user's choices. Both Front Door and Application Gateway WAF
+// backup files can be present in the supplied paths; each backup is dispatched
+// to the matching API based on its embedded WAFType field (or the resource
+// type of an explicit --target).
+func RestorePolicies(i *RestorePoliciesInput) error {
 	funcName := GetFunctionName()
 
-	if err = i.Validate(); err != nil {
+	if err := i.Validate(); err != nil {
 		return err
 	}
 
 	s := session.New()
 	s.AppVersion = i.AppVersion
 
-	if oerr := i.Validate(); oerr != nil {
-		return oerr
-	}
-
-	// load policies from path
 	logrus.Debugf("%s | loading paths %s", strings.Join(i.BackupsPaths, ", "), funcName)
 
-	wps, oerr := LoadBackupsFromPaths(i.BackupsPaths)
-	if oerr != nil {
-		return oerr
+	loaded, err := LoadAllBackupsFromPaths(i.BackupsPaths)
+	if err != nil {
+		return err
 	}
 
-	if len(wps) == 0 {
-		return fmt.Errorf(fmt.Sprintf("no backup files could be found in paths: %s", strings.Join(i.BackupsPaths, ", ")), funcName)
+	total := len(loaded.FrontDoor) + len(loaded.AppGW)
+	if total == 0 {
+		return fmt.Errorf("%s - no backup files could be found in paths: %s", funcName, strings.Join(i.BackupsPaths, ", "))
 	}
+
+	if i.TargetPolicy != "" && total > 1 {
+		return fmt.Errorf("%s - restoring more than one backup to a single policy doesn't make sense", funcName)
+	}
+
+	// if a target was specified, validate it matches the type of the loaded backup
+	if i.TargetPolicy != "" {
+		targetType := WAFTypeFromResourceID(i.TargetPolicy)
+
+		if !IsRIDHash(i.TargetPolicy) {
+			if targetType == WAFTypeAppGW && len(loaded.AppGW) == 0 {
+				return fmt.Errorf("%s - target is an Application Gateway WAF policy but the loaded backup is for Front Door", funcName)
+			}
+
+			if targetType == WAFTypeFrontDoor && len(loaded.FrontDoor) == 0 {
+				return fmt.Errorf("%s - target is a Front Door WAF policy but the loaded backup is for Application Gateway", funcName)
+			}
+		}
+	}
+
+	if len(loaded.FrontDoor) > 0 {
+		// pass a copy: restoreFrontDoorBackups writes resolved hashes and
+		// backup-derived targets into TargetPolicy, and those must not leak
+		// into the AppGW branch below
+		fdInput := *i
+		if err := restoreFrontDoorBackups(s, &fdInput, loaded.FrontDoor); err != nil {
+			return err
+		}
+	}
+
+	if len(loaded.AppGW) > 0 {
+		if err := restoreAppGWBackups(s, i, loaded.AppGW); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// restoreFrontDoorBackups encapsulates the original RestorePolicies behaviour
+// for Front Door WAF backups; it has been extracted so the AppGW path can sit
+// alongside it. It mutates i.TargetPolicy, so callers must pass a copy of the
+// input if they use it afterwards.
+func restoreFrontDoorBackups(s *session.Session, i *RestorePoliciesInput, wps []WrappedPolicy) error {
+	funcName := GetFunctionName()
+
+	explicitTarget := i.TargetPolicy != ""
 
 	if i.TargetPolicy != "" {
-		// ensure only single backup file loaded if targeting a policy
-		if len(wps) > 1 {
-			return fmt.Errorf("%s - restoring more than one backup to a single policy doesn't make sense", funcName)
-		}
-
 		if IsRIDHash(i.TargetPolicy) {
-			i.TargetPolicy, err = GetPolicyRIDByHash(nil, i.SubscriptionID, i.TargetPolicy)
+			resolved, err := GetPolicyRIDByHash(nil, i.SubscriptionID, i.TargetPolicy)
 			if err != nil {
 				return err
 			}
+
+			i.TargetPolicy = resolved
 		}
 	} else {
-		// if no target policy specified, then retrieve from backup
 		i.TargetPolicy = wps[0].PolicyID
 		logrus.Debugf("retrieved target id from backup: %s", i.TargetPolicy)
 	}
 
-	// restore loaded backups
 	policies, err := CompilePoliciesToRestore(s, wps, i)
 	if err != nil {
-		return
+		return err
 	}
 
-	if len(policies) > 0 {
-		// if target policy specified, there can be only one
-		if i.TargetPolicy != "" {
-			var rIDs []config.ResourceID
+	if len(policies) == 0 {
+		return nil
+	}
 
-			rIDs, err = ConvertToResourceIDs([]string{i.TargetPolicy}, i.SubscriptionID)
-			if err != nil {
-				return
-			}
-
-			policies[0].updated.SubscriptionID = rIDs[0].SubscriptionID
-			policies[0].updated.ResourceGroup = rIDs[0].ResourceGroup
-			policies[0].updated.Name = rIDs[0].Name
+	// only retarget when the user explicitly supplied --target: when the
+	// target was derived from the first backup, every compiled policy
+	// already carries that identity, making this override redundant
+	if explicitTarget {
+		rIDs, err := ConvertToResourceIDs([]string{i.TargetPolicy}, i.SubscriptionID)
+		if err != nil {
+			return err
 		}
 
-		for x := range policies {
-			err = ProcessPolicyChanges(&ProcessPolicyChangesInput{
-				Session:          s,
-				PolicyName:       policies[x].updated.Name,
-				SubscriptionID:   policies[x].updated.SubscriptionID,
-				ResourceGroup:    policies[x].updated.ResourceGroup,
-				ShowDiff:         i.ShowDiff,
-				PolicyPostChange: policies[x].updated.Policy,
-				DryRun:           i.DryRun,
-				Backup:           i.AutoBackup,
-				Debug:            i.Debug,
-			})
-			if err != nil {
-				return
-			}
+		policies[0].updated.SubscriptionID = rIDs[0].SubscriptionID
+		policies[0].updated.ResourceGroup = rIDs[0].ResourceGroup
+		policies[0].updated.Name = rIDs[0].Name
+	}
+
+	for x := range policies {
+		if err := ProcessPolicyChanges(&ProcessPolicyChangesInput{
+			Session:          s,
+			PolicyName:       policies[x].updated.Name,
+			SubscriptionID:   policies[x].updated.SubscriptionID,
+			ResourceGroup:    policies[x].updated.ResourceGroup,
+			ShowDiff:         i.ShowDiff,
+			PolicyPostChange: policies[x].updated.Policy,
+			DryRun:           i.DryRun,
+			Backup:           i.AutoBackup,
+			Debug:            i.Debug,
+		}); err != nil {
+			return fmt.Errorf("%s - %w", funcName, err)
 		}
 	}
 
-	return
+	return nil
 }
 
 type restorePair struct {
@@ -245,7 +288,11 @@ func shouldRestore(foundExisting bool, matched WrappedPolicy, backup WrappedPoli
 	}
 
 	switch {
-	case i.TargetPolicy != "" && i.DryRun:
+	// dry runs against an existing policy proceed without prompting. The
+	// foundExisting alternative matters for AppGW restores, which never
+	// derive a TargetPolicy from the backup; without it a no-target dry run
+	// would block on the interactive confirmation below.
+	case i.DryRun && (i.TargetPolicy != "" || foundExisting):
 		logrus.Debug("dry run only")
 		return true, nil
 	case i.TargetPolicy != "" && !foundExisting:

--- a/policy/utils.go
+++ b/policy/utils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
 
 	"github.com/jonhadfield/azwaf/helpers"
 	"github.com/ztrue/tracerr"
@@ -33,6 +34,27 @@ func toJSON(i interface{}) (out string, err error) {
 		var j []byte
 
 		j, err = json.MarshalIndent(v.Policy, "", "  ")
+		if err != nil {
+			return "", tracerr.Wrap(err)
+		}
+
+		return string(j), nil
+	case armnetwork.WebApplicationFirewallPolicy:
+		j, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return "", tracerr.Wrap(err)
+		}
+
+		return string(j), nil
+	case *armnetwork.WebApplicationFirewallPolicy:
+		j, err := json.MarshalIndent(*v, "", "  ")
+		if err != nil {
+			return "", tracerr.Wrap(err)
+		}
+
+		return string(j), nil
+	case WrappedAppGWPolicy:
+		j, err := json.MarshalIndent(v.Policy, "", "  ")
 		if err != nil {
 			return "", tracerr.Wrap(err)
 		}

--- a/scripts/diagnose-azure-env.sh
+++ b/scripts/diagnose-azure-env.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+echo "=== Azure Environment Diagnostics ==="
+echo ""
+
+echo "Environment variables being checked:"
+echo "AZURE_USE_MANAGED_IDENTITY: ${AZURE_USE_MANAGED_IDENTITY:-<not set>}"
+echo "WEBSITE_INSTANCE_ID: ${WEBSITE_INSTANCE_ID:-<not set>}"
+echo "IDENTITY_ENDPOINT: ${IDENTITY_ENDPOINT:-<not set>}"
+echo "IMDS_ENDPOINT: ${IMDS_ENDPOINT:-<not set>}"
+echo "MSI_ENDPOINT: ${MSI_ENDPOINT:-<not set>}"
+echo "ACC_CLOUD: ${ACC_CLOUD:-<not set>}"
+echo "AZURESUBSCRIPTION_CLIENT_ID: ${AZURESUBSCRIPTION_CLIENT_ID:-<not set>}"
+echo "AZURE_RESOURCE_GROUP: ${AZURE_RESOURCE_GROUP:-<not set>}"
+echo ""
+
+echo "Checking for Azure VM agent:"
+if [ -d "/var/lib/waagent" ]; then
+    echo "✓ /var/lib/waagent exists (Azure VM detected)"
+else
+    echo "✗ /var/lib/waagent not found"
+fi
+echo ""
+
+echo "Checking for IMDS endpoint:"
+if curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" --connect-timeout 2 > /dev/null 2>&1; then
+    echo "✓ IMDS endpoint is accessible (Managed Identity available)"
+else
+    echo "✗ IMDS endpoint not accessible"
+fi
+echo ""
+
+echo "Azure CLI status:"
+if command -v az &> /dev/null; then
+    echo "✓ Azure CLI found at: $(which az)"
+    az account show 2>&1 | head -5
+else
+    echo "✗ Azure CLI not found"
+fi

--- a/session/clients.go
+++ b/session/clients.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
 
 	"github.com/jonhadfield/azwaf/helpers"
 	"github.com/sirupsen/logrus"
@@ -82,7 +83,7 @@ func (s *Session) GetFrontDoorPoliciesClient(subID string) (err error) {
 
 	clientCreateStartTime := time.Now()
 	logrus.Infof("%s | Creating Azure Frontdoor client with optimized settings...", funcName)
-	
+
 	// Create client options with custom retry and timeout settings
 	clientOptions := &arm.ClientOptions{
 		ClientOptions: policy.ClientOptions{
@@ -96,10 +97,10 @@ func (s *Session) GetFrontDoorPoliciesClient(subID string) (err error) {
 			},
 		},
 	}
-	
+
 	frontDoorPoliciesClient, merr := armfrontdoor.NewPoliciesClient(subID, s.ClientCredential, clientOptions)
 	clientCreateDuration := time.Since(clientCreateStartTime)
-	
+
 	if merr != nil {
 		logrus.Errorf("%s | Failed to create client after %v: %s", funcName, clientCreateDuration, merr.Error())
 		return fmt.Errorf("%s - %s", funcName, merr.Error())
@@ -110,6 +111,60 @@ func (s *Session) GetFrontDoorPoliciesClient(subID string) (err error) {
 	logrus.Infof("%s | Successfully created client in %v (client creation: %v)", funcName, totalDuration, clientCreateDuration)
 
 	return
+}
+
+// GetAppGWPoliciesClient creates (or returns a cached) Application Gateway WAF
+// policies client for the given subscription.
+func (s *Session) GetAppGWPoliciesClient(subID string) error {
+	funcName := helpers.GetFunctionName()
+
+	if s == nil {
+		return errors.New("session is nil")
+	}
+
+	if subID == "" {
+		return fmt.Errorf("%s - subscription id is mandatory", funcName)
+	}
+
+	if s.AppGWPoliciesClients == nil {
+		s.AppGWPoliciesClients = make(map[string]*armnetwork.WebApplicationFirewallPoliciesClient)
+	}
+
+	if s.AppGWPoliciesClients[subID] != nil {
+		logrus.Debugf("re-using application gateway waf policies client for subscription: %s", subID)
+
+		return nil
+	}
+
+	if s.ClientCredential == nil {
+		if err := s.GetClientCredential(); err != nil {
+			return err
+		}
+	}
+
+	logrus.Debugf("creating application gateway waf policies client for subscription: %s", subID)
+
+	clientOptions := &arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Retry: policy.RetryOptions{
+				MaxRetries:    3,
+				RetryDelay:    time.Second,
+				MaxRetryDelay: time.Second * 30,
+			},
+			Telemetry: policy.TelemetryOptions{
+				ApplicationID: "azwaf",
+			},
+		},
+	}
+
+	c, merr := armnetwork.NewWebApplicationFirewallPoliciesClient(subID, s.ClientCredential, clientOptions)
+	if merr != nil {
+		return fmt.Errorf("%s - %s", funcName, merr.Error())
+	}
+
+	s.AppGWPoliciesClients[subID] = c
+
+	return nil
 }
 
 func (s *Session) GetManagedRuleSetsClient(subID string) (err error) {

--- a/session/config_test.go
+++ b/session/config_test.go
@@ -1,40 +1,40 @@
 package session
 
 import (
-    "os"
-    "path/filepath"
-    "testing"
+	"os"
+	"path/filepath"
+	"testing"
 
-    "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadFileBytes(t *testing.T) {
-    base := t.TempDir()
-    path := filepath.Join(base, "f.txt")
-    data := []byte("hello")
-    require.NoError(t, os.WriteFile(path, data, 0o600))
+	base := t.TempDir()
+	path := filepath.Join(base, "f.txt")
+	data := []byte("hello")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
 
-    b, err := ReadFileBytes(path)
-    require.NoError(t, err)
-    require.Equal(t, data, b)
+	b, err := ReadFileBytes(path)
+	require.NoError(t, err)
+	require.Equal(t, data, b)
 }
 
 func TestReadFileBytesError(t *testing.T) {
-    _, err := ReadFileBytes("/no/such/file")
-    require.Error(t, err)
-    require.Contains(t, err.Error(), "helpers.GetFunctionName")
+	_, err := ReadFileBytes("/no/such/file")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "helpers.GetFunctionName")
 }
 
 func TestLoadFileConfig(t *testing.T) {
-    data := []byte("policy_aliases:\n  foo: bar\n")
-    tmp := filepath.Join(t.TempDir(), "c.yaml")
-    require.NoError(t, os.WriteFile(tmp, data, 0o600))
+	data := []byte("policy_aliases:\n  foo: bar\n")
+	tmp := filepath.Join(t.TempDir(), "c.yaml")
+	require.NoError(t, os.WriteFile(tmp, data, 0o600))
 
-    cfg, err := LoadFileConfig(tmp)
-    require.NoError(t, err)
-    require.Equal(t, "bar", cfg.PolicyAliases["foo"])
+	cfg, err := LoadFileConfig(tmp)
+	require.NoError(t, err)
+	require.Equal(t, "bar", cfg.PolicyAliases["foo"])
 
-    cfg, err = LoadFileConfig("")
-    require.NoError(t, err)
-    require.Nil(t, cfg.PolicyAliases)
+	cfg, err = LoadFileConfig("")
+	require.NoError(t, err)
+	require.Nil(t, cfg.PolicyAliases)
 }

--- a/session/session.go
+++ b/session/session.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/jonhadfield/azwaf/helpers"
 	homedir "github.com/mitchellh/go-homedir"
@@ -30,6 +32,7 @@ type Session struct {
 	FrontDoorsClients                   map[string]*armfrontdoor.FrontDoorsClient
 	FrontDoorsManagedRuleSetsClients    map[string]*armfrontdoor.ManagedRuleSetsClient
 	FrontDoorsManagedRuleSetDefinitions []*armfrontdoor.ManagedRuleSetDefinition
+	AppGWPoliciesClients                map[string]*armnetwork.WebApplicationFirewallPoliciesClient
 	ResourcesClients                    map[string]*armresources.Client
 	WorkingDir                          string
 	BackupsDir                          string
@@ -225,7 +228,7 @@ func (s *Session) GetClientCredential() error {
 	logrus.Infof("%s | Trying environment credential first...", funcName)
 	envCred, envErr := azidentity.NewEnvironmentCredential(nil)
 	envDuration := time.Since(envStartTime)
-	
+
 	if envErr == nil {
 		logrus.Infof("%s | Environment credential created in %v", funcName, envDuration)
 		s.ClientCredential = envCred
@@ -247,7 +250,7 @@ func (s *Session) GetClientCredential() error {
 		}
 		miCred, miErr := azidentity.NewManagedIdentityCredential(nil)
 		miDuration := time.Since(miStartTime)
-		
+
 		if miErr == nil {
 			logrus.Infof("%s | Managed identity credential created in %v", funcName, miDuration)
 			s.ClientCredential = miCred
@@ -270,7 +273,7 @@ func (s *Session) GetClientCredential() error {
 		logrus.Infof("%s | Azure CLI binary found at %s, trying Azure CLI credential...", funcName, azPath)
 		cliCred, cliErr := azidentity.NewAzureCLICredential(nil)
 		cliDuration := time.Since(cliStartTime)
-		
+
 		if cliErr == nil {
 			logrus.Infof("%s | Azure CLI credential created in %v", funcName, cliDuration)
 			s.ClientCredential = cliCred
@@ -288,13 +291,13 @@ func (s *Session) GetClientCredential() error {
 	// Don't use DefaultAzureCredential as it would retry managed identity and cause hangs
 	totalDuration := time.Since(startTime)
 	logrus.Errorf("%s | All credential methods failed after %v", funcName, totalDuration)
-	
+
 	errorMsg := fmt.Sprintf("%s | No valid Azure credentials found after %v. Please authenticate using one of:\n", funcName, totalDuration)
 	errorMsg += "  1. Environment variables (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID)\n"
 	errorMsg += "  2. Azure CLI (run 'az login')\n"
 	if inAzure {
 		errorMsg += "  3. Managed Identity (when running in Azure)\n"
 	}
-	
-	return fmt.Errorf(errorMsg)
+
+	return errors.New(errorMsg)
 }

--- a/testfiles/wrapped-appgw-policy-one.json
+++ b/testfiles/wrapped-appgw-policy-one.json
@@ -1,0 +1,28 @@
+{
+    "Date": "2026-01-01T00:00:00Z",
+    "SubscriptionID": "00000000-0000-0000-0000-000000000000",
+    "ResourceGroup": "rg-one",
+    "Name": "appgw-policy-one",
+    "Policy": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-one/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/appgw-policy-one",
+        "name": "appgw-policy-one",
+        "location": "eastus",
+        "properties": {
+            "managedRules": {
+                "managedRuleSets": [
+                    {
+                        "ruleSetType": "OWASP",
+                        "ruleSetVersion": "3.2"
+                    }
+                ]
+            },
+            "policySettings": {
+                "state": "Enabled",
+                "mode": "Prevention"
+            }
+        }
+    },
+    "PolicyID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-one/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/appgw-policy-one",
+    "AppVersion": "test",
+    "WAFType": "ApplicationGateway"
+}


### PR DESCRIPTION
## Summary

Extends `backup` and `restore` to handle **Azure Application Gateway WAF policies** alongside Front Door. Each resource ID's embedded resource type determines which API a policy is fetched from or restored to; running `backup` with no arguments now snapshots every WAF policy of either type in the subscription.

- New backup files are tagged with a `WAFType` field so restore can dispatch to the correct API; older backups without the field load as Front Door for backward compatibility
- `policy/appgw.go` — AppGW policy fetch/push/load/diff via the `armnetwork` v7 SDK, plus WAF type detection from resource IDs
- `policy/appgw_restore.go` — AppGW restore pipeline: diff display, pre-change auto-backup, dry-run, and first-time create when the target policy doesn't exist yet (typed 404 detection)
- Session gains a cached AppGW policies client per subscription; `ParseResourceID` now captures the resource type component
- README rewritten as a full command reference documenting the new support

## Fixes included

Issues found during adversarial review of the feature, plus a few pre-existing bugs in the touched files:

- **restore**: the Front Door branch operates on a copy of the input, so its `TargetPolicy` mutations can't leak into the AppGW branch (mixed-type restores previously failed)
- **restore**: retargeting of the first compiled policy is gated on an explicit `--target`, preventing a mis-retarget when a backup is declined at the confirmation prompt
- **restore**: dry runs against an existing policy no longer block on an interactive prompt when no `--target` is given
- **backup**: `--fail-fast` no longer stops after the first policy on success; fail-slow mode now logs per-policy errors instead of swallowing them; a marshal failure skips the policy instead of writing an empty backup file
- `BuildRestoredAppGWPolicy` clones `Properties` before assigning rule sets, so the caller's policy is not mutated through a shared pointer
- `calculatePatchStats` now counts whole-section rule changes (a policy gaining `customRules` where it had none was previously reported as "identical" and skipped)
- Assorted error-wrapping fixes (non-constant `fmt.Errorf` format strings), a `go vet` fix in `session`, and gofmt cleanup

## Behavior changes to note

- `backup --fail-fast` with multiple policies now backs up **all** of them until an error occurs (previously it silently stopped after the first)
- Fail-slow backups log per-policy failures but exit 0 (consistent across FD/AppGW)
- AppGW dry-runs without `--target` no longer prompt interactively

## Testing

- `go build ./...`, `go vet ./...`, and `gofmt -l` are all clean
- New unit tests in `policy/appgw_test.go` cover WAF type detection, resource ID partitioning, backup-file dispatch by type, and restore construction
- **Not yet tested against live Azure** — manual verification of backup/restore against real FD and AppGW policies is planned before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)